### PR TITLE
Extend enforced position declarations to RESULTS

### DIFF
--- a/csvpath/references/functions/fields/actual_data_file_3.py
+++ b/csvpath/references/functions/fields/actual_data_file_3.py
@@ -22,3 +22,4 @@ class ActualDataFile3(Function3):
     KEY = {
         Reference3.RESULT: "actual_data_file",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/completed_3.py
+++ b/csvpath/references/functions/fields/completed_3.py
@@ -24,3 +24,4 @@ class Completed3(Function3):
         Reference3.RESULTS: "all_completed",
         Reference3.RESULT: "completed",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/file_fingerprints_3.py
+++ b/csvpath/references/functions/fields/file_fingerprints_3.py
@@ -22,3 +22,4 @@ class FileFingerprints3(Function3):
     KEY = {
         Reference3.RESULT: "file_fingerprints",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/files_complete_3.py
+++ b/csvpath/references/functions/fields/files_complete_3.py
@@ -25,3 +25,4 @@ class FilesComplete3(Function3):
         Reference3.RESULTS: "all_expected_files",
         Reference3.RESULT: "files_expected",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/home_3.py
+++ b/csvpath/references/functions/fields/home_3.py
@@ -42,4 +42,9 @@ class Home3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_ONE, Reference3.NAME_THREE),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: same dual shape as FILES -- bare, name_one, zero-
+        # level-selector (settled 2026-08-11) AND the ordinary name_three
+        # field-accessor position (KEY has both RESULTS and RESULT
+        # entries -- run AND instance scope).
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/fields/hostname_3.py
+++ b/csvpath/references/functions/fields/hostname_3.py
@@ -13,3 +13,4 @@ class Hostname3(Function3):
     KEY = {
         Reference3.RESULTS: "hostname",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/identity_3.py
+++ b/csvpath/references/functions/fields/identity_3.py
@@ -22,3 +22,4 @@ class Identity3(Function3):
     KEY = {
         Reference3.RESULT: "instance_identity",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/manifest_path_3.py
+++ b/csvpath/references/functions/fields/manifest_path_3.py
@@ -26,4 +26,7 @@ class ManifestPath3(Function3):
         Reference3.RESULTS: "manifest_path",
         Reference3.RESULT: "manifest_path",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+    }

--- a/csvpath/references/functions/fields/method_3.py
+++ b/csvpath/references/functions/fields/method_3.py
@@ -13,3 +13,4 @@ class Method3(Function3):
     KEY = {
         Reference3.RESULTS: "method",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/named_file_name_3.py
+++ b/csvpath/references/functions/fields/named_file_name_3.py
@@ -30,4 +30,7 @@ class NamedFileName3(Function3):
         Reference3.RESULTS: "named_file_name",
         Reference3.RESULT: "named_file_name",
     }
-    POSITIONS = {Reference3.FILES: (Reference3.NAME_THREE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_THREE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+    }

--- a/csvpath/references/functions/fields/named_paths_name_3.py
+++ b/csvpath/references/functions/fields/named_paths_name_3.py
@@ -25,4 +25,9 @@ class NamedPathsName3(Function3):
         Reference3.CSVPATHS: "named_paths_name",
         Reference3.RESULTS: "named_paths_name",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: KEY only has a RESULTS entry, no RESULT (instance)
+        # entry -- run scope only.
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/named_results_name_3.py
+++ b/csvpath/references/functions/fields/named_results_name_3.py
@@ -17,3 +17,4 @@ class NamedResultsName3(Function3):
         Reference3.RESULTS: "named_results_name",
         Reference3.RESULT: "named_results_name",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/origin_data_file_3.py
+++ b/csvpath/references/functions/fields/origin_data_file_3.py
@@ -26,3 +26,4 @@ class OriginDataFile3(Function3):
     KEY = {
         Reference3.RESULT: "origin_data_file",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/preceding_instance_identity_3.py
+++ b/csvpath/references/functions/fields/preceding_instance_identity_3.py
@@ -25,3 +25,4 @@ class PrecedingInstanceIdentity3(Function3):
     KEY = {
         Reference3.RESULT: "preceding_instance_identity",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/run_uuid_3.py
+++ b/csvpath/references/functions/fields/run_uuid_3.py
@@ -30,3 +30,4 @@ class RunUuid3(Function3):
         Reference3.RESULTS: "run_uuid",
         Reference3.RESULT: "run_uuid",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/serial_3.py
+++ b/csvpath/references/functions/fields/serial_3.py
@@ -26,3 +26,4 @@ class Serial3(Function3):
         Reference3.RESULTS: "serial",
         Reference3.RESULT: "serial",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/fields/source_mode_preceding_3.py
+++ b/csvpath/references/functions/fields/source_mode_preceding_3.py
@@ -16,3 +16,4 @@ class SourceModePreceding3(Function3):
     KEY = {
         Reference3.RESULT: "source_mode_preceding",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/fields/status_3.py
+++ b/csvpath/references/functions/fields/status_3.py
@@ -23,3 +23,4 @@ class Status3(Function3):
     KEY = {
         Reference3.RESULTS: "status",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/time_3.py
+++ b/csvpath/references/functions/fields/time_3.py
@@ -30,4 +30,5 @@ class Time3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/fields/time_completed_3.py
+++ b/csvpath/references/functions/fields/time_completed_3.py
@@ -24,4 +24,10 @@ class TimeCompleted3(Function3):
         Reference3.CSVPATHS: "time_completed",
         Reference3.RESULTS: "time_completed",
     }
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: KEY only has a RESULTS entry, no RESULT (instance)
+        # entry -- run scope only (matches the class's own docstring:
+        # "RESULTS instance scope is deliberately excluded").
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/fields/username_3.py
+++ b/csvpath/references/functions/fields/username_3.py
@@ -13,3 +13,4 @@ class Username3(Function3):
     KEY = {
         Reference3.RESULTS: "username",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/fields/uuid_3.py
+++ b/csvpath/references/functions/fields/uuid_3.py
@@ -47,4 +47,8 @@ class Uuid3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: KEY has both RESULTS ("run_uuid", per the class's own
+        # docstring on why run scope reads that instead of a deprecated
+        # bare "uuid") and RESULT ("uuid", instance scope) entries.
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/fields/valid_3.py
+++ b/csvpath/references/functions/fields/valid_3.py
@@ -30,3 +30,4 @@ class Valid3(Function3):
         Reference3.RESULTS: "all_valid",
         Reference3.RESULT: "valid",
     }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE)}

--- a/csvpath/references/functions/selectors/all_3.py
+++ b/csvpath/references/functions/selectors/all_3.py
@@ -31,4 +31,9 @@ class All3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: name_one (one-level GROUP, run-level) AND name_three
+        # (:all() pools every instance in the run) -- unlike FILES/
+        # CSVPATHS, both positions are genuinely legal, not aliases of
+        # the same underlying slot.
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/selectors/first_3.py
+++ b/csvpath/references/functions/selectors/first_3.py
@@ -12,4 +12,8 @@ class First3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: name_one only -- name_three has no pointer concept of
+        # its own (_name_three_selector recognizes a literal identity,
+        # :all(), or ':from()'/':to()', never a pointer).
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
     }

--- a/csvpath/references/functions/selectors/flatten_3.py
+++ b/csvpath/references/functions/selectors/flatten_3.py
@@ -37,8 +37,7 @@ class Flatten3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    #
-    # RESULTS entry deferred until that Finder is retrofitted to enforce
-    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
-    #
-    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/from_3.py
+++ b/csvpath/references/functions/selectors/from_3.py
@@ -57,13 +57,12 @@ class From3(Function3):
     #
     # FILES: name_three only (its own version-selector position -- no
     # name_one range, unlike CSVPATHS/RESULTS' own version-level range,
-    # since FILES' version selector never lives in name_one). CSVPATHS:
-    # both name_one (version-level range) and name_three (statement-
-    # level range). RESULTS entries deferred until that Finder is
-    # retrofitted to enforce POSITIONS the same way (see
-    # Function3.POSITIONS's own docstring).
+    # since FILES' version selector never lives in name_one). CSVPATHS/
+    # RESULTS: both name_one (run/version-level range) and name_three
+    # (statement/instance-level range).
     #
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/selectors/groups_3.py
+++ b/csvpath/references/functions/selectors/groups_3.py
@@ -35,8 +35,7 @@ class Groups3(Function3):
     DATATYPES = (Reference3.FILES, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False
-    #
-    # RESULTS entry deferred until that Finder is retrofitted to enforce
-    # POSITIONS the same way (see Function3.POSITIONS's own docstring).
-    #
-    POSITIONS = {Reference3.FILES: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.FILES: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/functions/selectors/index_3.py
+++ b/csvpath/references/functions/selectors/index_3.py
@@ -20,4 +20,6 @@ class Index3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # see First3's own POSITIONS comment.
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
     }

--- a/csvpath/references/functions/selectors/last_3.py
+++ b/csvpath/references/functions/selectors/last_3.py
@@ -12,4 +12,6 @@ class Last3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # see First3's own POSITIONS comment.
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
     }

--- a/csvpath/references/functions/selectors/name_3.py
+++ b/csvpath/references/functions/selectors/name_3.py
@@ -36,6 +36,12 @@ class Name3(Function3):
     # ReferenceFinder3._check_position().
     #
     POSITIONS = {
+        # FILES/RESULTS: name_one PATH-BUILDING position (a segment
+        # within name_one.path, alongside literal/'*' segments -- see
+        # the shared ReferenceFinder3._compile_path_pattern(), which
+        # already enforces this on its own; not part of the trailing
+        # function-chain _check_position() validates).
         Reference3.FILES: (Reference3.NAME_ONE,),
         Reference3.CSVPATHS: (),
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
     }

--- a/csvpath/references/functions/selectors/to_3.py
+++ b/csvpath/references/functions/selectors/to_3.py
@@ -34,4 +34,5 @@ class To3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
+        Reference3.RESULTS: (Reference3.NAME_ONE, Reference3.NAME_THREE),
     }

--- a/csvpath/references/functions/well_known_files/data_3.py
+++ b/csvpath/references/functions/well_known_files/data_3.py
@@ -21,3 +21,4 @@ class Data3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/well_known_files/errors_3.py
+++ b/csvpath/references/functions/well_known_files/errors_3.py
@@ -32,3 +32,4 @@ class Errors3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = (Idchain3,)
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/well_known_files/file_3.py
+++ b/csvpath/references/functions/well_known_files/file_3.py
@@ -24,6 +24,7 @@ class File3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = (str,)
     ARG_REQUIRED = True
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}
 
     def check_valid(self) -> None:
         super().check_valid()

--- a/csvpath/references/functions/well_known_files/manifest_3.py
+++ b/csvpath/references/functions/well_known_files/manifest_3.py
@@ -51,4 +51,11 @@ class Manifest3(Function3):
     POSITIONS = {
         Reference3.FILES: (Reference3.NAME_THREE,),
         Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        # RESULTS: name_one only -- resolves to the selected RUN's own
+        # manifest.json (confirmed 2026-08-13); :manifest() is not
+        # recognized at name_three (_name_three_selector has no case for
+        # it -- it is not a content accessor and SOURCE is None, so it
+        # does not match field_call either -- falls through to that
+        # loop's own catch-all raise).
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
     }

--- a/csvpath/references/functions/well_known_files/meta_3.py
+++ b/csvpath/references/functions/well_known_files/meta_3.py
@@ -20,3 +20,4 @@ class Meta3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/well_known_files/unmatched_3.py
+++ b/csvpath/references/functions/well_known_files/unmatched_3.py
@@ -22,3 +22,4 @@ class Unmatched3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/functions/well_known_files/vars_3.py
+++ b/csvpath/references/functions/well_known_files/vars_3.py
@@ -20,3 +20,4 @@ class Vars3(Function3):
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_THREE,)}

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -192,6 +192,21 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         home = self.csvpaths.results_manager.get_named_results_home(root_major)
         run_homes = [rh for rh, _ in self._discover_run_homes(root_major)]
         calls = self._combined_name_one_calls(name_one)
+        # added 2026-08-14 -- the same fix already made for CSVPATHS'
+        # _resolve_versions() and FILES' name_three chain: replaces
+        # nothing here (there was no equivalent "at least one recognized
+        # category" gate to redundantly cover), it CLOSES a real gap --
+        # confirmed via direct testing before this fix that
+        # "$acme.results.:last():webhooks()" (a function registered for
+        # a DIFFERENT datatype entirely, not even results-relevant)
+        # silently no-opped instead of raising, since every check below
+        # only ever looks for SPECIFIC recognized names, never rejects
+        # an unrecognized extra riding alongside them. Does not touch
+        # name_one's own PATH-BUILDING segments (literal/'*'/:name()) --
+        # those are already safe, validated separately and correctly by
+        # the shared ReferenceFinder3._compile_path_pattern().
+        for f in ReferenceFunctionFactory.build_chain(calls):
+            self._check_position(f, Reference3.NAME_ONE, Reference3.RESULTS)
         pointer = self._pointer_from_calls(calls)
         is_grouped = any(
             isinstance(c, FunctionCall3) and c.name == "all" for c in calls
@@ -571,23 +586,27 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
         calls = self._combined_name_one_calls(name_one)
         built = ReferenceFunctionFactory.build_chain(calls)
-        if any(f.name in ("all", "flatten", "manifest") for f in built):
-            # ':flatten()' would be a no-op here anyway -- traversal
-            # already pools every discovered run at the same (zero)
-            # level, unlike the literal-root case's plain bare pointer
-            # -- but rejecting it explicitly avoids silently applying
-            # the zero-level filter to what should be an any-depth
-            # query, rather than quietly doing the wrong thing.
+        # added 2026-08-14 -- replaces two separate, still-incomplete
+        # checks (an "all()/flatten()/manifest() by name" check and a
+        # separate field-function check) with one that actually covers
+        # every case this method's own docstring restriction implies
+        # ("only a bare pointer... is supported so far"). Confirmed via
+        # direct testing before this fix that neither replaced check
+        # actually caught everything it should have -- ':groups()' and
+        # ':from()' both silently swallowed instead of raising, the
+        # same bug class already fixed for the literal-root case above.
+        # ':flatten()' would have been a no-op here anyway (traversal
+        # already pools every discovered run at the same zero level),
+        # but rejecting it explicitly, like everything else that is not
+        # a pointer, still avoids silently applying that filter to what
+        # should be an any-depth query.
+        non_pointers = [f for f in built if f.ROLE != Function3.POINTER]
+        if non_pointers:
             raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support ':all()', "
-                "':flatten()', or ':manifest()' combined with '*' "
-                "traversal -- only a bare pointer (:first()/:last()/"
-                ":index(n)) is supported so far."
-            )
-        if self._find_field_function_call(calls) is not None:
-            raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support a field-"
-                "accessor function combined with '*' traversal."
+                f"ResultsReferenceFinder3 does not yet support "
+                f":{non_pointers[0].name}() combined with '*' traversal -- "
+                "only a bare pointer (:first()/:last()/:index(n)) is "
+                "supported so far."
             )
         pointer = self._pointer_from_calls(calls)
         if pointer is None:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1739,6 +1739,53 @@ class TestStarTraversal:
             _finder("$*.results.:last().0", two_group_archive).query()
 
 
+class TestPositionEnforcement:
+    # ReferenceFinder3._check_position() -- added 2026-08-14, the
+    # enforced replacement for the scattered "is this recognized"
+    # guards each Finder used to hand-write on its own. RESULTS is the
+    # third and last Finder retrofitted to call it, after CSVPATHS and
+    # FILES.
+    def test_an_unregistered_for_this_datatype_function_on_name_one_is_rejected(
+        self, acme_archive
+    ):
+        # the actual bug this closes: name_one's own handling only ever
+        # looked for SPECIFIC recognized names (all/flatten/groups/from/
+        # to/manifest/a field function) -- it never rejected an
+        # unrecognized extra riding alongside a legitimate pointer.
+        # Confirmed via direct testing before this fix that
+        # ":last():webhooks()" (a function registered for a DIFFERENT
+        # datatype entirely, not even results-relevant) silently
+        # no-opped instead of raising.
+        with pytest.raises(ReferenceException3):
+            _finder("$acme.results.customers/2025:last():webhooks()", acme_archive).query()
+
+    def test_a_legal_function_is_unaffected(self, acme_archive):
+        # sanity check that the new check does not over-reject.
+        results = _finder("$acme.results.customers/2025:last()", acme_archive).query()
+        assert results.results[0].uuid == "run2-uuid"
+
+    def test_star_traversal_rejects_groups_not_just_all_flatten_manifest(
+        self, two_group_archive
+    ):
+        # the old star-traversal guard only named-checked
+        # "all"/"flatten"/"manifest" plus a separate field-function
+        # check -- neither caught ':groups()', confirmed via direct
+        # testing before this fix that it silently no-opped instead of
+        # raising. Replaced with one check covering everything that is
+        # not a bare pointer, matching the method's own documented
+        # restriction.
+        with pytest.raises(ReferenceException3):
+            _finder("$*.results.:last():groups()", two_group_archive).query()
+
+    def test_star_traversal_rejects_a_range_function_too(self, two_group_archive):
+        with pytest.raises(ReferenceException3):
+            _finder("$*.results.:last():from(1)", two_group_archive).query()
+
+    def test_star_traversal_bare_pointer_is_unaffected(self, two_group_archive):
+        results = _finder("$*.results.:last()", two_group_archive).query()
+        assert results.results[0].uuid == "widgets-run1-uuid"
+
+
 class TestScopeLimits:
     def test_star_root_major_not_yet_supported(self, acme_archive):
         finder = _finder("$*.results.customers/2025:last()", acme_archive)

--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -23,17 +23,14 @@ Mechanically derived every run (always accurate, no manual upkeep): role,
 datatypes, arg shape, source, unit-test-file-exists, integration-test-grep-
 hit-per-datatype, and position for every function.
 
-Position itself is a mix of two sources, preferring the real one whenever
-it exists: **CSVPATHS and FILES position are now real, ENFORCED declared
-data** (Function3.POSITIONS, added 2026-08-14 -- see ReferenceFinder3.
-_check_position(), called from CsvpathsReferenceFinder3 and
-FilesReferenceFinder3) -- this script just reads it straight off each
-function class, same as DATATYPES/ROLE. **RESULTS position is still hand-
-curated** in SPECIAL_POSITIONS/SPECIAL_NOTES below (or mechanically
-guessed for plain field accessors via _default_position()) -- that Finder
-has not been retrofitted to declare/enforce POSITIONS yet, so there is no
-real data to read for it. Once RESULTS gets the same retrofit, this whole
-hand-curated mechanism goes away entirely.
+Position for EVERY datatype is now real, ENFORCED declared data
+(Function3.POSITIONS, added 2026-08-14 -- see ReferenceFinder3.
+_check_position(), called from all three Finders as of the same day RESULTS
+was retrofitted) -- this script just reads it straight off each function
+class, same as DATATYPES/ROLE. The SPECIAL_NOTES dict below is the one
+remaining hand-curated piece -- short semantic explanations that do not fit
+a position label (e.g. why a function is legal in two positions, or what it
+means at each), not a fallback data source.
 """
 
 import re
@@ -42,7 +39,6 @@ from pathlib import Path
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory as RFF,
 )
-from csvpath.references.reference_3 import Reference3
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -62,37 +58,11 @@ INTEGRATION_TEST_FILES = {
 }
 
 #
-# manually curated RESULTS positions for the ~20 functions that are NOT
-# plain field accessors -- see module docstring. No "files"/"csvpaths"
-# keys in any entry below -- both are now real declared data, read
-# directly off each function class in main(), taking precedence over
-# anything here (this dict is consulted only as a RESULTS fallback). One
-# entry: a position string, or None (not supported/not meaningful there).
+# short semantic explanations for functions whose position alone does not
+# tell the whole story -- keyed by NAME, applies across whichever
+# datatypes the function is registered for. Everything not listed here
+# gets DEFAULT_NOTE if it is a plain field accessor, or nothing.
 #
-SPECIAL_POSITIONS = {
-    "first": {"results": "name_one"},
-    "last": {"results": "name_one"},
-    "index": {"results": "name_one"},
-    "name": {"results": None},
-    "all": {"results": "name_one"},
-    "flatten": {"results": "name_one"},
-    "groups": {"results": "name_one"},
-    "having": {"results": None},
-    "from": {"results": "name_one, name_three"},
-    "to": {"results": "name_one, name_three"},
-    "date": {"results": "argument (inside :from()/:to())"},
-    "manifest": {"results": "name_one"},
-    "definition": {"results": None},
-    "path": {"results": None},
-    "errors": {"results": "name_three (instance-level)"},
-    "vars": {"results": "name_three (instance-level)"},
-    "meta": {"results": "name_three (instance-level)"},
-    "data": {"results": "name_three (instance-level)"},
-    "unmatched": {"results": "name_three (instance-level)"},
-    "file": {"results": "name_three (instance-level)"},
-    "idchain": {"results": "argument (inside :errors())"},
-}
-
 SPECIAL_NOTES = {
     "name": (
         "DATATYPES includes csvpaths, but name_one has no path-building "
@@ -157,51 +127,26 @@ def _integration_hits(name: str, datatype: str) -> bool:
     return False
 
 
-def _default_position(cls, datatype: str) -> str | None:
-    """mechanical GUESS at position for a plain field accessor (SOURCE
-    set, not in SPECIAL_POSITIONS), for RESULTS only -- that Finder is
-    not retrofitted to enforce real POSITIONS data yet (main() never
-    calls this for FILES/CSVPATHS -- see its own comment). Derived from
-    whether the function's own KEY dict serves the run level
-    (Reference3.RESULTS), the instance level (Reference3.RESULT), or
-    both."""
-    if datatype not in (cls.DATATYPES or ()):
-        return None
-    has_run = Reference3.RESULTS in cls.KEY
-    has_instance = Reference3.RESULT in cls.KEY
-    if has_run and has_instance:
-        return "name_one, name_three"
-    if has_instance:
-        return "name_three (instance-level only)"
-    if has_run:
-        return "name_one (run-level only)"
-    return "name_one"  # SOURCE="-" default-shape functions not otherwise flagged
-
-
 def main() -> None:
     RFF.get_registered_class("first")  # triggers _load() -- see factory's own laziness
     rows = []
     for name, cls in sorted(RFF._FUNCTIONS.items()):
         datatypes = cls.DATATYPES or ()
         unit_tested = _unit_test_path(cls).exists()
-        positions = SPECIAL_POSITIONS.get(name)
-        note = SPECIAL_NOTES.get(name, DEFAULT_NOTE if positions is None else "")
+        is_plain_field_accessor = cls.SOURCE is not None
+        note = SPECIAL_NOTES.get(
+            name, DEFAULT_NOTE if is_plain_field_accessor else ""
+        )
         cells = {}
         for dt in ("files", "csvpaths", "results"):
-            if dt in (Reference3.FILES, Reference3.CSVPATHS):
-                # real, enforced data -- see module docstring. No
-                # fallback guessing here: since FilesReferenceFinder3/
-                # CsvpathsReferenceFinder3 now fail-close on anything
-                # without a POSITIONS entry (see ReferenceFinder3.
-                # _check_position()), a guessed default could show
-                # "looks fine" for a function that would actually be
-                # rejected at runtime.
-                declared = cls.POSITIONS.get(dt)
-                pos = ", ".join(declared) if declared else None
-            elif positions is not None:
-                pos = positions.get(dt)
-            else:
-                pos = _default_position(cls, dt)
+            # real, enforced data for every datatype (see module
+            # docstring). No fallback guessing: since every Finder now
+            # fail-closes on anything without a POSITIONS entry (see
+            # ReferenceFinder3._check_position()), a guessed default
+            # could show "looks fine" for a function that would
+            # actually be rejected at runtime.
+            declared = cls.POSITIONS.get(dt)
+            pos = ", ".join(declared) if declared else None
             tested = _integration_hits(name, dt) if dt in datatypes else None
             cells[dt] = (pos, tested)
         rows.append(
@@ -229,8 +174,8 @@ def main() -> None:
     out.append(
         "Generated by `tests/references/tools/generate_function_matrix.py` -- "
         "re-run any time the function registry or test files change; do not "
-        "hand-edit the table below (edit the script's own `SPECIAL_POSITIONS`/"
-        "`SPECIAL_NOTES` dicts instead, for the manually-curated parts).\n\n"
+        "hand-edit the table below (edit the script's own `SPECIAL_NOTES` "
+        "dict instead, for the one remaining manually-curated part).\n\n"
     )
     out.append(
         "| Function | Role | Datatypes | Arg required | Source | Unit test | "


### PR DESCRIPTION
## Summary
- Third and last Finder retrofitted, completing the CSVPATHS-then-FILES-then-RESULTS sequence agreed earlier.
- All 37 RESULTS-relevant functions now declare `POSITIONS[results]` (`:date()`/`:idchain()` correctly exempt -- argument-only wrappers, never a top-level chain member).
- Derived from a fresh, careful read of `results_reference_finder_3.py` (the largest and most bespoke of the three) rather than assumption -- the derivation held up cleanly against the existing 139-test suite on the first run, no corrections needed (unlike the FILES retrofit, where two draft positions were wrong and caught immediately).

## What this actually fixes
Two real bugs, same class as the CSVPATHS/FILES fixes:
- **`query()`'s literal-root name_one handling had no catch-all at all** -- every existing check only looked for SPECIFIC recognized names, never rejected an unrecognized extra riding alongside a legitimate pointer. Confirmed via direct testing that `$acme.results.:last():webhooks()` (a function registered for a *different* datatype entirely) silently no-opped instead of raising.
- **`_query_star_traversal()`'s own guard had the same gap in its own narrower scope** -- its two separate checks did not cover `:groups()` or `:from()`, both confirmed silently swallowed before this fix. Replaced both with one check ("everything that is not a POINTER role is rejected"), which actually matches the method's own documented restriction more completely than what it replaces.

**Deliberately NOT touched, and why:**
- `_name_three_selector()` already has a correct, complete catch-all (`else: raise` for anything unrecognized) -- confirmed via reading it, no bug there. Swapping it for the generic check would be a pure refactor with no behavior change, not worth the risk in the most complex of the three Finders.
- name_one's own PATH-BUILDING segments (literal/`*`/`:name()`) are already safe by construction via the shared `_compile_path_pattern()`.

## Other changes
- Retires the function coverage matrix's entire hand-curated fallback mechanism (`SPECIAL_POSITIONS`, `_default_position()`) now that all three datatypes have real, enforced position data -- every cell in the matrix is read straight off the function registry now, no guessing left anywhere.
- Added `TestPositionEnforcement` to `test_results_reference_finder_3.py`.

## Test plan
- [x] `tests/references/test_results_reference_finder_3.py` + `test_normative_examples_results.py` -- 168 passed
- [x] `tests/references/` -- 1021 passed
- [x] Full suite -- 2609 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)
