### PR TITLE
Close real RESULTS field-accessor test gaps, fix matrix false positives

### DIFF
--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1416,6 +1416,59 @@ class TestFieldAccessorFunctions:
         ).resolve()
         assert result.results[0].data == instance_manifest_path
 
+    def test_named_results_name_shared_key_both_scopes(self, tmp_path):
+        # same literal key ("named_results_name") at both scopes -- see
+        # run_uuid_3.py's own docstring for why a shared value still
+        # needs two KEY entries, one per scope the finder dispatches on.
+        base = tmp_path / "widgets"  # direct child of the group's own home
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {"run_uuid": "run-uuid", "named_results_name": "widgets"},
+        )
+        _write_json(
+            run_dir / "company_names" / "manifest.json",
+            {"uuid": "inst-uuid", "named_results_name": "widgets"},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        run_name = _finder(
+            "$widgets.results.:first():named_results_name()", str(tmp_path)
+        ).resolve()
+        assert run_name.results[0].data == "widgets"
+
+        instance_name = _finder(
+            "$widgets.results.:first().company_names:named_results_name()",
+            str(tmp_path),
+        ).resolve()
+        assert instance_name.results[0].data == "widgets"
+
+    def test_time_at_run_and_instance_scope(self, tmp_path):
+        # same literal key ("time") at both scopes -- confirmed real,
+        # written fields in results_registrar.py/result_registrar.py:
+        # run start time, and this one statement's own start time.
+        base = tmp_path / "widgets"  # direct child of the group's own home
+        run_dir = base / "2026-01-01_00-00-00"
+        _write_json(
+            run_dir / "manifest.json",
+            {"run_uuid": "run-uuid", "time": "2026-01-01T00:00:00+00:00"},
+        )
+        _write_json(
+            run_dir / "company_names" / "manifest.json",
+            {"uuid": "inst-uuid", "time": "2026-01-01T00:00:05+00:00"},
+        )
+        _write_archive_manifest(tmp_path, "widgets", [str(run_dir)])
+
+        run_time = _finder(
+            "$widgets.results.:first():time()", str(tmp_path)
+        ).resolve()
+        assert run_time.results[0].data == "2026-01-01T00:00:00+00:00"
+
+        instance_time = _finder(
+            "$widgets.results.:first().company_names:time()", str(tmp_path)
+        ).resolve()
+        assert instance_time.results[0].data == "2026-01-01T00:00:05+00:00"
+
 
 class TestWellKnownFileAccessors:
     # :errors()/:vars()/:meta() resolve to parsed JSON; :data()/

--- a/tests/references/tools/generate_function_matrix.py
+++ b/tests/references/tools/generate_function_matrix.py
@@ -110,20 +110,42 @@ def _unit_test_path(function_cls) -> Path:
 
 def _integration_hits(name: str, datatype: str) -> bool:
     # require both a '$' (a real reference string's own marker) and
-    # ':name(' on the SAME line -- a bare ':from()'/':to()' mention in a
-    # comment/docstring (extremely common in this codebase) would
-    # otherwise false-positive as "tested" with a plain ':name\(' search.
-    # Deliberately NOT excluding quote characters between the two: a
-    # nested string arg (e.g. ':name("orders.csv").:from(1):to(3)') puts
-    # quotes between '$' and a LATER function call on the same line, so
-    # excluding them would wrongly break the match at the first nested arg.
-    pattern = re.compile(r"\$.*:" + re.escape(name) + r"\(")
+    # ':name(' within a short span of each other -- a bare ':from()'/
+    # ':to()' mention in a comment/docstring (extremely common in this
+    # codebase) would otherwise false-positive as "tested" with a plain
+    # ':name\(' search. Deliberately NOT excluding quote characters in
+    # that span: a nested string arg (e.g. ':name("orders.csv").
+    # :from(1):to(3)') puts quotes between '$' and a LATER function call,
+    # so excluding them would wrongly break the match at the first
+    # nested arg. Spans a short window ACROSS lines, non-greedy, rather
+    # than requiring the same line -- a reference string broken across
+    # two lines by ordinary Python string-literal concatenation (e.g.
+    # ':idchain()' in a real test, confirmed 2026-08-16: '$acme...'
+    # then, on the next line, ':errors(:idchain(...))') would otherwise
+    # be invisible to this check. 200 characters is generous for that
+    # (real split points are a handful of characters apart) while still
+    # far short of the gap between one test's own reference strings and
+    # an unrelated LATER test's, which would need this to false-match
+    # across tests instead of within one.
+    #
+    # KNOWN, NOT FIXED HERE: a reference string built via an f-string or
+    # a helper that inserts the function name as a variable (e.g.
+    # "f'$widgets.results.:first():{fn}()'", or a resolve(fn)-style
+    # helper called as resolve("status")) is invisible to ANY text
+    # search, since the literal text ':status(' never appears in the
+    # source at all -- confirmed 2026-08-16 this accounted for most of
+    # a "15 gaps" report that was actually only 2 real gaps. A
+    # **MISSING** flag from this script is a prompt to go look, not
+    # proof of an actual gap -- see this function's own limitation
+    # before trusting it at face value.
+    pattern = re.compile(
+        r"\$.{0,200}?:" + re.escape(name) + r"\(", re.DOTALL
+    )
     for path in INTEGRATION_TEST_FILES[datatype]:
         if not path.exists():
             continue
-        for line in path.read_text().splitlines():
-            if pattern.search(line):
-                return True
+        if pattern.search(path.read_text()):
+            return True
     return False
 
 


### PR DESCRIPTION
## Summary
Closes the RESULTS field-accessor test gaps flagged by the coverage matrix -- with a correction: the "15 gaps" report was mostly a tooling artifact, not real missing coverage.

## What actually happened
Before writing any tests, checked each flagged function against the real test file. 13 of the 15 were already tested end-to-end:
- `test_run_only_field_accessors`/`test_instance_only_field_accessors` already cover `status`, `method`, `hostname`, `username`, `time_completed`, `manifest_path`, `named_paths_name`, `identity`, `actual_data_file`, `origin_data_file`, `file_fingerprints`, `source_mode_preceding`, `preceding_instance_identity` -- via a `resolve(fn)` helper that builds the reference string from an f-string variable, so the literal text `:status(` never appears in the source for a text search to find.
- `:idchain()` was similarly already tested, just split across two lines by ordinary Python string-literal concatenation, outside the matrix tool's same-line search window.

Fixed the tool (`generate_function_matrix.py`) to search a short, non-greedy window across lines instead of requiring the same line -- correctly picks up the `idchain` case without over-matching across unrelated tests. Documented the f-string blind spot directly in the tool's own code as a known, unfixable-by-text-search limitation, so a future **MISSING** flag reads as "go look," not "definitely missing."

That leaves two *actually* missing tests, both added here with real manifests at both run and instance scope: `:named_results_name()` and `:time()`.

## Test plan
- [x] `tests/references/` -- 1023 passed
- [x] Full suite -- 2611 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)
- [x] Matrix gap count: 15 -> 12, all 12 remaining confirmed false positives from the documented f-string limitation, not real gaps
