### PR TITLE
Add the two building blocks reference expressions will need

### DIFF
--- a/csvpath/references/reference_finder_factory_3.py
+++ b/csvpath/references/reference_finder_factory_3.py
@@ -1,0 +1,50 @@
+from .csvpaths_reference_finder_3 import CsvpathsReferenceFinder3
+from .files_reference_finder_3 import FilesReferenceFinder3
+from .reference_3 import Reference3
+from .reference_exceptions_3 import ReferenceException3
+from .reference_finder_3 import ReferenceFinder3
+from .reference_parser_3 import ReferenceParser3
+from .results_reference_finder_3 import ResultsReferenceFinder3
+
+
+class ReferenceFinderFactory3:
+    #
+    # given a raw reference string, picks and constructs the right
+    # ReferenceFinder3 subclass for its own datatype -- nothing did this
+    # automatically before (every test, and every real usage so far,
+    # hand-picks Files/Csvpaths/ResultsReferenceFinder3 directly). Built
+    # for ReferenceExpression3, whose two sides are each just a plain
+    # reference string that could be any of the three datatypes -- see
+    # references_notes/notes/reference_expressions_notes.txt's own
+    # ARCHITECTURE section. Mirrors ReferenceFunctionFactory's own
+    # name-keyed dispatch shape (reference_function_factory_3.py), just
+    # keyed on datatype instead of function name.
+    #
+    _FINDERS = {
+        Reference3.FILES: FilesReferenceFinder3,
+        Reference3.CSVPATHS: CsvpathsReferenceFinder3,
+        Reference3.RESULTS: ResultsReferenceFinder3,
+    }
+
+    @classmethod
+    def for_reference(cls, *, reference: str, csvpaths) -> ReferenceFinder3:
+        """parses `reference` and returns a real ReferenceFinder3 for
+        whichever datatype it turns out to be. Reference3's own
+        constructor already guarantees datatype is one of FILES/
+        CSVPATHS/RESULTS (raises ValueError otherwise, at parse time) --
+        the lookup below cannot actually miss today, but stays a real
+        checked dispatch rather than a bare index, so a future fourth
+        datatype fails here clearly instead of deeper inside whichever
+        Finder class happens to get picked by accident."""
+        if not reference:
+            raise ValueError("ReferenceFinderFactory3 reference cannot be None or empty")
+        if csvpaths is None:
+            raise ValueError("ReferenceFinderFactory3 csvpaths cannot be None")
+        ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
+        finder_cls = cls._FINDERS.get(ref.parsed.datatype)
+        if finder_cls is None:
+            raise ReferenceException3(
+                f"ReferenceFinderFactory3 has no ReferenceFinder3 registered "
+                f"for datatype {ref.parsed.datatype!r}."
+            )
+        return finder_cls(csvpaths=csvpaths, ref=ref)

--- a/csvpath/references/reference_results_3.py
+++ b/csvpath/references/reference_results_3.py
@@ -138,6 +138,26 @@ class ReferenceResults3:
         ]
         return ReferenceResults3(results=selected)
 
+    def deduplicated(self) -> "ReferenceResults3":
+        """a new ReferenceResults3 with duplicate entries (by
+        ReferenceResult3's own __eq__ -- path+uuid+data+identity)
+        collapsed, first occurrence wins, order preserved -- added
+        2026-08-17 for ReferenceExpression3's own UNION, which combines
+        two datatypes' native results with no join-key logic at all
+        (see references_notes/notes/reference_expressions_notes.txt's
+        own ARCHITECTURE section: UNION never looks at a resolved field
+        value, only at whether two results are already the same
+        result). ReferenceResult3 has no __hash__ (defining __eq__
+        without one already makes it unhashable, the correct default --
+        see ReferenceResult3.data, a mutable field, which is exactly
+        why), so this is a linear scan per entry, not a hash-set
+        dedup -- fine at the result-set sizes this operates on."""
+        seen: list = []
+        for result in self._results:
+            if result not in seen:
+                seen.append(result)
+        return ReferenceResults3(results=seen)
+
     def remove(self, result: ReferenceResult3) -> None:
         """drops one result in place -- for the "iterate, decide, trim"
         workflow: walk the results, remove the ones you do not want,

--- a/tests/references/test_reference_finder_factory_3.py
+++ b/tests/references/test_reference_finder_factory_3.py
@@ -1,0 +1,121 @@
+import pytest
+
+from csvpath.references.csvpaths_reference_finder_3 import CsvpathsReferenceFinder3
+from csvpath.references.files_reference_finder_3 import FilesReferenceFinder3
+from csvpath.references.reference_finder_factory_3 import ReferenceFinderFactory3
+from csvpath.references.results_reference_finder_3 import ResultsReferenceFinder3
+
+
+class _FakeFileManager:
+    def named_file_home(self, name):
+        return f"inputs/named_files/{name}"
+
+    def get_manifest(self, name):
+        return []
+
+    @property
+    def named_file_names(self):
+        return []
+
+    @property
+    def files_root_manifest(self):
+        return []
+
+
+class _FakePathsManager:
+    def get_manifest_for_name(self, name):
+        return []
+
+    def named_paths_home(self, name):
+        return f"named_paths/{name}"
+
+    @property
+    def named_paths_names(self):
+        return []
+
+    @property
+    def paths_root_manifest(self):
+        return []
+
+
+class _FakeResultsManager:
+    def get_named_results_home(self, name):
+        return f"archive/{name}"
+
+    @property
+    def results_root_manifest(self):
+        return []
+
+
+class _FakeConfig:
+    def get(self, section, name):
+        return "archive"
+
+    inputs_files_path = None
+    inputs_csvpaths_path = None
+
+
+class _FakeCsvPaths:
+    def __init__(self):
+        self.file_manager = _FakeFileManager()
+        self.paths_manager = _FakePathsManager()
+        self.results_manager = _FakeResultsManager()
+        self.config = _FakeConfig()
+
+
+def _csvpaths() -> _FakeCsvPaths:
+    return _FakeCsvPaths()
+
+
+class TestReferenceFinderFactory3:
+    def test_files_reference_gives_a_files_finder(self):
+        finder = ReferenceFinderFactory3.for_reference(
+            reference='$alpha.files.:name("orders.csv").:last()', csvpaths=_csvpaths()
+        )
+        assert isinstance(finder, FilesReferenceFinder3)
+
+    def test_csvpaths_reference_gives_a_csvpaths_finder(self):
+        finder = ReferenceFinderFactory3.for_reference(
+            reference="$acme.csvpaths.:last()", csvpaths=_csvpaths()
+        )
+        assert isinstance(finder, CsvpathsReferenceFinder3)
+
+    def test_results_reference_gives_a_results_finder(self):
+        finder = ReferenceFinderFactory3.for_reference(
+            reference="$acme.results.:last()", csvpaths=_csvpaths()
+        )
+        assert isinstance(finder, ResultsReferenceFinder3)
+
+    def test_the_returned_finder_is_actually_usable(self):
+        # not just the right class -- constructed correctly enough to
+        # run query() without blowing up, given only empty fake
+        # manifests.
+        finder = ReferenceFinderFactory3.for_reference(
+            reference="$acme.csvpaths.:last()", csvpaths=_csvpaths()
+        )
+        results = finder.query()
+        assert results.results == []
+
+    @pytest.mark.parametrize("bad_reference", [None, ""])
+    def test_rejects_none_or_empty_reference(self, bad_reference):
+        with pytest.raises(ValueError):
+            ReferenceFinderFactory3.for_reference(
+                reference=bad_reference, csvpaths=_csvpaths()
+            )
+
+    def test_rejects_none_csvpaths(self):
+        with pytest.raises(ValueError):
+            ReferenceFinderFactory3.for_reference(
+                reference="$acme.results.:last()", csvpaths=None
+            )
+
+    def test_an_unparseable_reference_raises(self):
+        # a grammar-level failure (no leading '$') raises straight from
+        # the Lark parser, not ReferenceException3 -- confirmed via
+        # direct testing; ReferenceParser3 only wraps exceptions raised
+        # from INSIDE a transformer rule (e.g. Reference3's own
+        # validation), not raw grammar/tokenizing failures.
+        with pytest.raises(Exception):
+            ReferenceFinderFactory3.for_reference(
+                reference="not a reference at all", csvpaths=_csvpaths()
+            )

--- a/tests/references/test_reference_results_3.py
+++ b/tests/references/test_reference_results_3.py
@@ -131,6 +131,54 @@ class TestReferenceResults3:
     def test_equality(self):
         assert self._results() == self._results()
 
+    def test_deduplicated_with_no_duplicates_is_unchanged(self):
+        r = self._results()
+        assert r.deduplicated().files == ["p1", "p2"]
+
+    def test_deduplicated_collapses_exact_duplicates(self):
+        results = [
+            ReferenceResult3(path="p1", uuid="u1"),
+            ReferenceResult3(path="p2", uuid="u2"),
+            ReferenceResult3(path="p1", uuid="u1"),
+        ]
+        r = ReferenceResults3(results=results)
+        deduped = r.deduplicated()
+        assert deduped.files == ["p1", "p2"]
+        assert len(deduped) == 2
+
+    def test_deduplicated_preserves_first_occurrence_order(self):
+        results = [
+            ReferenceResult3(path="p3", uuid="u3"),
+            ReferenceResult3(path="p1", uuid="u1"),
+            ReferenceResult3(path="p3", uuid="u3"),
+            ReferenceResult3(path="p2", uuid="u2"),
+        ]
+        r = ReferenceResults3(results=results)
+        assert r.deduplicated().files == ["p3", "p1", "p2"]
+
+    def test_deduplicated_uses_full_equality_not_just_path(self):
+        # same path+uuid but different data, or different identity, are
+        # NOT duplicates -- see ReferenceResult3.__eq__ and its own
+        # identity docstring for why.
+        results = [
+            ReferenceResult3(path="p1", uuid="u1", data="a"),
+            ReferenceResult3(path="p1", uuid="u1", data="b"),
+            ReferenceResult3(path="p1", uuid="u1", identity="x"),
+            ReferenceResult3(path="p1", uuid="u1", identity="y"),
+        ]
+        r = ReferenceResults3(results=results)
+        assert len(r.deduplicated()) == 4
+
+    def test_deduplicated_on_empty_results_is_empty(self):
+        assert ReferenceResults3().deduplicated().results == []
+
+    def test_deduplicated_returns_a_new_instance_not_the_original(self):
+        r = self._results()
+        deduped = r.deduplicated()
+        assert deduped is not r
+        deduped.remove(deduped.results[0])
+        assert len(r) == 2
+
 
 class TestRemove:
     def _results(self, n=3):


### PR DESCRIPTION
## Summary
First concrete step toward reference expressions (`UNION`/`SUBTRACT`/`INTERSECT` over references). Adds the two small, independently-testable pieces the settled design (`references_notes/notes/reference_expressions_notes.txt`) calls for, before wiring up `ReferenceExpression3` itself.

- **`ReferenceFinderFactory3.for_reference()`** -- given a raw reference string, parses it and returns the right one of `Files`/`Csvpaths`/`ResultsReferenceFinder3` for its own datatype. Nothing did this automatically before -- every existing caller (all tests, so far) hand-picks the right Finder class directly. A reference expression's two sides are each just a plain string that could be any of the three datatypes, so this dispatch needs to exist somewhere.
- **`ReferenceResults3.deduplicated()`** -- a new `ReferenceResults3` with duplicate entries (by `ReferenceResult3`'s own existing `__eq__` -- path+uuid+data+identity) collapsed, first occurrence wins, order preserved. This is what `UNION` will use directly -- per the settled design, `UNION` never looks at a resolved join-key value at all, it's pure concatenation of both sides' native results with duplicates collapsed.

## Test plan
- [x] `tests/references/test_reference_finder_factory_3.py` (new) -- 8 passed
- [x] `tests/references/test_reference_results_3.py` -- 31 passed (6 new dedup tests)
- [x] `tests/references/` -- 1037 passed
- [x] Full suite -- 2625 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)

`ReferenceExpression3` itself (the actual UNION/SUBTRACT/INTERSECT logic on top of these two pieces) is the next step, not included here.
