### PR TITLE
Add ReferenceExpression3 -- UNION/SUBTRACT/INTERSECT over references

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -263,7 +263,15 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
           chronological order across everything, not enumeration order
           (csvpaths has no path dimension the way files does, so there
           is nothing to pattern-match -- every entry in every group's
-          manifest is a candidate).
+          manifest is a candidate). A pointer is OPTIONAL here too
+          (settled 2026-08-19) -- absence means every candidate comes
+          back, unreduced, same as GROUP mode's own no-pointer case
+          below already did; this was the one place csvpaths' own star
+          traversal still required one unconditionally, an
+          inconsistency (not a deliberate choice) fixed once RESULTS'
+          equivalent fix (matching RESULTS' own literal-root behavior
+          and FilesReferenceFinder3, neither of which ever required
+          one either) made the asymmetry obvious.
         - ':all()' present in the combined chain (GROUP): the pointer
           is applied independently within each group's own manifest
           (plain array order -- no time-sort needed within one group)
@@ -327,16 +335,34 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         # 3+-function chain reaches the guard below.
         calls = [name_one.path[0], *name_one.functions]
         built = ReferenceFunctionFactory.build_chain(calls)
-        is_grouped = any(f.name == "all" for f in built)
+        all_call = next((f for f in built if f.name == "all"), None)
+        is_grouped = all_call is not None
         having_call = next((f for f in built if f.name == "having"), None)
+        field_call = self._find_field_function_call(built)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
-        unsupported = any(f.name == "manifest" for f in built) or any(
-            f.name in ("from", "to") for f in built
-        )
-        if unsupported:
+        # whitelist-based (settled 2026-08-19), replacing an earlier
+        # blacklist-based check (any(name=="manifest") or any(name in
+        # ("from","to"))) that only ever rejected those two specific
+        # names -- a real, previously-latent gap this fix closes, not
+        # just a stale test: confirmed live, before this fix, that
+        # "$*.csvpaths.:definition()" silently fell through as if it
+        # were a no-op (":definition()" is neither a pointer nor ':all()'
+        # /':having()'/a field accessor, but was also never explicitly
+        # rejected either) once the "no pointer" case stopped forcing a
+        # raise for an unrelated reason. Mirrors RESULTS' own
+        # non_pointers pattern in _star_run_selector_chain() exactly.
+        non_pointers = [
+            f
+            for f in built
+            if f.ROLE != Function3.POINTER
+            and f is not all_call
+            and f is not having_call
+            and f is not field_call
+        ]
+        if non_pointers:
             raise ReferenceException3(
-                "CsvpathsReferenceFinder3 does not yet support combining "
-                "'*' traversal with :manifest() or ':from()'/':to()' -- "
+                f"CsvpathsReferenceFinder3 does not yet support "
+                f":{non_pointers[0].name}() combined with '*' traversal -- "
                 "only a plain pointer (:first()/:last()/:index(n)), "
                 "optionally combined with :all(), :having(\"identity\"), "
                 "or a registered field-accessor function (e.g. :uuid()), "
@@ -365,13 +391,23 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 else:
                     selected_versions.extend(manifest)
         else:
-            if not pointers:
-                raise ReferenceException3(
-                    "CsvpathsReferenceFinder3 requires a pointer (:first()/"
-                    ":last()/:index(n)) when traversing every named-paths "
-                    "group with '*' -- use :all() for one result per "
-                    "group instead."
-                )
+            # a pointer is now OPTIONAL here too (settled 2026-08-19,
+            # alongside RESULTS' own equivalent fix) -- absence means
+            # every matched version comes back, unreduced, the same
+            # meaning a missing pointer already has in GROUP mode above
+            # (is_grouped's own "else: selected_versions.extend(manifest)"),
+            # at csvpaths' own single-group _resolve_versions() precedent,
+            # and at RESULTS' star traversal (see
+            # ResultsReferenceFinder3._star_run_selector_chain()'s own
+            # comment on why RESULTS was changed to match its own
+            # literal-root behavior and FilesReferenceFinder3, neither of
+            # which ever required one). This POOL branch was the one
+            # remaining place csvpaths' own star traversal still required
+            # a pointer unconditionally -- confirmed, before this fix,
+            # that it was a real inconsistency (not a deliberate,
+            # permanent design choice) since nothing about pooling itself
+            # needs a pointer to be meaningful, same as GROUP mode already
+            # proved.
             pooled = []
             for name in self.csvpaths.paths_manager.named_paths_names:
                 pooled.extend(
@@ -380,8 +416,11 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                     )
                 )
             pooled.sort(key=lambda e: e["time"])
-            selected = self._apply_pointer(pointers[0], pooled)
-            selected_versions = [selected] if selected is not None else []
+            if pointers:
+                selected = self._apply_pointer(pointers[0], pooled)
+                selected_versions = [selected] if selected is not None else []
+            else:
+                selected_versions = pooled
 
         return ReferenceResults3(
             results=[

--- a/csvpath/references/reference_expression_3.py
+++ b/csvpath/references/reference_expression_3.py
@@ -1,0 +1,179 @@
+from .reference_exceptions_3 import ReferenceException3
+from .reference_finder_factory_3 import ReferenceFinderFactory3
+from .reference_results_3 import ReferenceResults3
+
+
+class ReferenceExpression3:
+    #
+    # a logical operation (UNION/SUBTRACT/INTERSECT) applied to two
+    # references, for questions a single reference cannot answer alone
+    # -- see references_notes/notes/reference_expressions_notes.txt for
+    # the full worked-through design (SEMANTICS/ARCHITECTURE sections,
+    # settled 2026-08-17). Each side is either a plain reference string
+    # (dispatched through ReferenceFinderFactory3, so it can be any of
+    # the three datatypes) or another ReferenceExpression3
+    # (sub-expressions) -- either way, each side is fully resolve()d to
+    # its own ReferenceResults3 before the operation combines them.
+    #
+    # UNION never looks at resolved data at all -- it is pure
+    # concatenation of both sides' own native results, with duplicates
+    # (by ReferenceResult3's own __eq__) collapsed via
+    # ReferenceResults3.deduplicated(). If the caller wants to see which
+    # items on one side correlate with which on the other, that is done
+    # AFTER the union, by the caller, comparing .data across the merged
+    # results themselves -- not something this computes.
+    #
+    # INTERSECT/SUBTRACT use a join key instead: whatever scalar each
+    # side's own trailing field accessor resolved to (result.data,
+    # already populated by resolve() -- e.g. :identity(), :uuid(),
+    # :named_paths_name()), NOT path/uuid, which mean different things
+    # per datatype and are not comparable across them. Both are FILTERS,
+    # not joins that multiply rows: a left-hand ITEM survives
+    # (INTERSECT) or is dropped (SUBTRACT) based on whether its key
+    # exists anywhere on the right, regardless of how many right-hand
+    # items share that key.
+    #
+    # Only the RIGHT side is reduced to a plain set of keys -- which
+    # right-hand item carried a given key never matters, since right-
+    # hand items never appear in the output, only their key VALUES do.
+    # The LEFT side is NOT collapsed by key -- corrected 2026-08-18,
+    # caught by testing against David's own "orders" example (two
+    # named-paths groups, 2 runs for one, 3 for the other): an earlier
+    # draft of this class deduplicated the left side by key too, before
+    # filtering, which silently collapsed group A's 2 runs and group
+    # B's 3 runs down to 1 each -- wrong, since "give me all the runs"
+    # means every matching run, not one exemplar per distinct group
+    # name. The left side IS still deduplicated by full ReferenceResult3
+    # equality first (dropping true duplicate items, never a different
+    # item that merely shares a key) -- that is always safe, regardless
+    # of which of these two examples you are in. A caller who genuinely
+    # wants "one result per distinct key" output (the overnight-
+    # regression example's own goal, not this one) gets that by calling
+    # ReferenceResults3.deduplicated() themselves on whichever side
+    # needs it before handing it to an expression -- not something this
+    # class forces on every INTERSECT/SUBTRACT.
+    #
+    # A None-valued key never matches anything, on either side -- for
+    # INTERSECT that means a None-keyed left item can never be confirmed
+    # to match, so it never survives; for SUBTRACT it means a None-keyed
+    # left item can never be matched away, so it always survives. A key
+    # that is not hashable (e.g. a side's trailing accessor resolved to
+    # a list/dict -- :named_paths_identities(), :file_fingerprints(),
+    # :scripts()/:webhooks()/:transfers()) raises clearly here rather
+    # than failing confusingly deep inside a set.
+    #
+    # Output is always a flat ReferenceResults3, same shape as a single
+    # reference's own results -- each surviving item keeps its own real
+    # path/uuid/data intact, in the left-hand side's own original order;
+    # nothing pairs/merges two sides' items into one row.
+    #
+    UNION = "union"
+    SUBTRACT = "subtract"
+    INTERSECT = "intersect"
+    _OPERATIONS = (UNION, SUBTRACT, INTERSECT)
+
+    def __init__(
+        self,
+        *,
+        left: "str | ReferenceExpression3",
+        op: str,
+        right: "str | ReferenceExpression3",
+        csvpaths,
+    ) -> None:
+        if not isinstance(left, (str, ReferenceExpression3)) or left == "":
+            raise ValueError(
+                "ReferenceExpression3 left must be a non-empty reference "
+                "string or another ReferenceExpression3"
+            )
+        if op not in self._OPERATIONS:
+            raise ValueError(
+                f"ReferenceExpression3 op must be one of {self._OPERATIONS}, "
+                f"got {op!r}"
+            )
+        if not isinstance(right, (str, ReferenceExpression3)) or right == "":
+            raise ValueError(
+                "ReferenceExpression3 right must be a non-empty reference "
+                "string or another ReferenceExpression3"
+            )
+        if csvpaths is None:
+            raise ValueError("ReferenceExpression3 csvpaths cannot be None")
+        self._left = left
+        self._op = op
+        self._right = right
+        self._csvpaths = csvpaths
+
+    def resolve(self) -> ReferenceResults3:
+        left_results = self._resolve_side(self._left)
+        right_results = self._resolve_side(self._right)
+        if self._op == self.UNION:
+            return self._union(left_results, right_results)
+        if self._op == self.INTERSECT:
+            return self._intersect(left_results, right_results)
+        return self._subtract(left_results, right_results)
+
+    def _resolve_side(self, side: "str | ReferenceExpression3") -> ReferenceResults3:
+        if isinstance(side, ReferenceExpression3):
+            return side.resolve()
+        return ReferenceFinderFactory3.for_reference(
+            reference=side, csvpaths=self._csvpaths
+        ).resolve()
+
+    @staticmethod
+    def _union(left: ReferenceResults3, right: ReferenceResults3) -> ReferenceResults3:
+        combined = ReferenceResults3(results=[*left.results, *right.results])
+        return combined.deduplicated()
+
+    @classmethod
+    def _intersect(
+        cls, left: ReferenceResults3, right: ReferenceResults3
+    ) -> ReferenceResults3:
+        right_keys = cls._keys(right)
+        kept = []
+        for item in left.deduplicated().results:
+            if item.data is None:
+                continue
+            if cls._hashable(item.data) in right_keys:
+                kept.append(item)
+        return ReferenceResults3(results=kept)
+
+    @classmethod
+    def _subtract(
+        cls, left: ReferenceResults3, right: ReferenceResults3
+    ) -> ReferenceResults3:
+        right_keys = cls._keys(right)
+        kept = []
+        for item in left.deduplicated().results:
+            if item.data is None:
+                kept.append(item)
+                continue
+            if cls._hashable(item.data) not in right_keys:
+                kept.append(item)
+        return ReferenceResults3(results=kept)
+
+    @classmethod
+    def _keys(cls, results: ReferenceResults3) -> set:
+        """the set of distinct, hashable, non-None join-key values
+        present in `results` -- used only to test LEFT-hand membership
+        for INTERSECT/SUBTRACT. Which item on this side carried a given
+        key never matters here -- see this class's own docstring for
+        why RIGHT-hand items themselves never appear in the output."""
+        keys = set()
+        for item in results.results:
+            if item.data is None:
+                continue
+            keys.add(cls._hashable(item.data))
+        return keys
+
+    @staticmethod
+    def _hashable(key):
+        try:
+            hash(key)
+        except TypeError:
+            raise ReferenceException3(
+                f"ReferenceExpression3 cannot use a {type(key).__name__} "
+                f"({key!r}) as a join key -- INTERSECT/SUBTRACT need each "
+                "side's trailing accessor to resolve to a hashable scalar "
+                "(e.g. :identity(), :uuid(), :named_paths_name()), not a "
+                "list/dict-valued one."
+            ) from None
+        return key

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -25,19 +25,21 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    paths group that was run), or "*" (every named-results group). "*" has
 #    two exceptions carved out before general traversal (Rule 1a/1b, a
 #    bare/ordinal-indexed :manifest() reads the global archive ledger); any
-#    other use of "*" goes through _query_star_traversal(), which is
-#    deliberately the narrowest of the three datatypes' traversals -- a bare
-#    pointer, optionally combined with ':flatten()', ':all()' (added
-#    2026-08-18/2026-08-19), and/or a run-level field-accessor function, but
-#    still no path narrowing/name_three/:manifest() -- see that method's own
-#    docstring for why the remaining wider cases are genuinely harder here,
-#    not just unbuilt yet. ':all()' here partitions by the COMPOSITE (named-
-#    results group, 1-level template value) key, resolving a real meaning-
-#    collision -- see "THE ':all()' MEANING COLLISION AT STAR TRAVERSAL" in
-#    references_notes/notes/normative_reference_examples.txt for the worked
-#    example that settled it, and FilesReferenceFinder3's own equivalent
-#    ':all()' precedent (its "file_home" key already IS a composite key,
-#    the named-file's name embedded as a path prefix).
+#    other use of "*" goes through _query_star_traversal(), which mirrors
+#    query()'s own dispatch tree (bare/':flatten()'/':all()'/literal-'*'
+#    path, ':groups()' still deferred) across every group instead of one
+#    fixed home -- see that method's own docstring for the full history
+#    (2026-08-14 through 2026-08-19) and why ':manifest()' alone stays
+#    unsupported. name_three (an instance selector) composes with every
+#    shape too. A pointer is now OPTIONAL everywhere here (settled
+#    2026-08-19, matching RESULTS' own literal-root precedent and
+#    FilesReferenceFinder3's star traversal, which never requires one
+#    either) -- absence means every matched run comes back, unreduced.
+#    ':all()' partitions by the COMPOSITE (named-results group, 1-level
+#    template value) key when a pointer IS present, resolving a real
+#    meaning-collision -- see "THE ':all()' MEANING COLLISION AT STAR
+#    TRAVERSAL" in references_notes/notes/normative_reference_examples.txt
+#    for the worked example that settled it.
 #  - name_one has TWO legal shapes, matching the spec's own examples
 #    ("$acme.results.:all()"/"$acme.results.:last()" alongside
 #    "$acme.results.customers/2025:first()"):
@@ -550,6 +552,21 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         selected run directory (see _extract_data()'s own has_manifest
         branch) -- a separate, still-open gap, not attempted here.
 
+        A pointer is now OPTIONAL in every shape above (settled
+        2026-08-19, via _star_run_selector_chain()) -- absence means
+        every matched run comes back, unreduced, the same meaning a
+        missing pointer already has at every literal-root query() shape
+        (none of them require one). Confirmed against the closest
+        sibling datatype before making this change:
+        FilesReferenceFinder3's own '*' traversal never requires a
+        pointer either, in any of its four modes -- see this module's
+        own top-of-file docstring for the full comparison, including
+        CsvpathsReferenceFinder3's own partial (POOL-requires-it,
+        GROUP-does-not) precedent, which this deliberately does NOT
+        copy (RESULTS' own literal-root behavior and FILES both make it
+        optional everywhere, a stronger and more directly relevant
+        precedent than CSVPATHS' narrower one).
+
         Chronological order across every group cannot use a full-path
         string sort the way one group's own query() case can get away
         with (different groups' run directories live under different
@@ -742,7 +759,26 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         _results_for_run() already builds each candidate's
         ReferenceResult3 from its own real run directory, independent
         of any group-name context, so resolving a field from it needs
-        nothing star-traversal-specific."""
+        nothing star-traversal-specific.
+
+        A pointer itself is now OPTIONAL here (changed 2026-08-19) --
+        absence means "every matched run, unreduced," the SAME meaning
+        a missing pointer already has at every literal-root query()
+        shape (bare/':flatten()'/':all()' alike -- none of them require
+        one there). Confirmed against the closest sibling datatype
+        before making this change: FilesReferenceFinder3's own '*'
+        traversal NEVER requires a pointer either, in any of its four
+        modes (see its own _query_star_traversal docstring) -- a
+        missing pointer there returns a deduped list of distinct
+        file_home values. RESULTS does not need FILES' dedup-plus-
+        uuid=None trick (each candidate here is already a distinct real
+        run directory via _discover_run_homes()'s own dedup, so every
+        unreduced result can carry its own real run uuid, not a
+        placeholder). CsvpathsReferenceFinder3 is the outlier here, not
+        the target precedent -- it requires a pointer in POOL/flatten
+        mode but not GROUP/':all()' mode, an asymmetry noted but not
+        touched (a separate, already-merged PR, not blocking anything
+        needed here)."""
         built = ReferenceFunctionFactory.build_chain(calls)
         field_call = self._find_field_function_call(built)
         all_call = next((f for f in built if f.name == "all"), None)
@@ -771,12 +807,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "supported so far."
             )
         pointer = self._pointer_from_calls(calls)
-        if pointer is None:
-            raise ReferenceException3(
-                "ResultsReferenceFinder3 requires a pointer (:first()/"
-                ":last()/:index(n)) when traversing every named-results "
-                "group with '*'."
-            )
         return pointer, all_call, flatten_call
 
     def _star_pool_and_reduce(
@@ -790,11 +820,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
     ) -> ReferenceResults3:
         """POOL mode's shared tail -- added 2026-08-19, alongside
         _star_group_and_reduce(), factored out once name_three needed
-        threading through every star-traversal shape identically. No
-        "more than one candidate + content accessor" guard is needed
-        here (unlike the GROUP case) -- a pointer is always required in
-        POOL mode, so exactly one run is ever selected."""
+        threading through every star-traversal shape identically. A
+        missing pointer (added 2026-08-19, see _star_run_selector_chain()'s
+        own comment for why) means every matched run comes back,
+        unreduced -- which can now be MORE than one run, so the same
+        "more than one candidate + content accessor" guard the GROUP
+        case already needs applies here too."""
         run_homes = sorted(run_homes, key=self._run_dir_sort_key)
+        if pointer is None:
+            if len(run_homes) > 1 and accessor is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3 does not yet support combining "
+                    "unreduced '*' traversal (no pointer, more than one "
+                    "matched run) with a name_three content accessor -- "
+                    "resolve the matched runs on their own first."
+                )
+            results = []
+            for run_dir in run_homes:
+                results.extend(
+                    self._results_for_run(
+                        run_dir, identity, match_all, range_bounds, accessor
+                    )
+                )
+            return ReferenceResults3(results=results)
         selected = self._apply_pointer(pointer, run_homes)
         if selected is None:
             return ReferenceResults3(results=[])
@@ -829,12 +877,38 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         A name_three FIELD accessor (e.g. ".invoices:uuid()") is NOT
         rejected -- confirmed live against the already-shipped literal-
         root precedent (":all():last().invoices:uuid()" resolves fine,
-        poolable, one result per matched run) before writing this."""
-        if accessor is not None:
+        poolable, one result per matched run) before writing this.
+
+        A missing pointer (added 2026-08-19) means every matched run
+        comes back, unreduced -- mirroring CsvpathsReferenceFinder3's
+        own already-shipped ':all()'-with-no-pointer precedent
+        (extends the filtered manifest, ungrouped) exactly: once there
+        is no pointer to reduce a partition to one, the partitioning
+        itself stops mattering for the OUTPUT (every member of every
+        partition just comes back), so this degenerates to the same
+        "list everything, unreduced" case _star_pool_and_reduce()
+        already handles -- delegated there directly rather than
+        duplicating that logic."""
+        if accessor is not None and pointer is not None:
+            # the content-accessor rejection only applies when grouping
+            # can still yield more than one run (pointer present, one
+            # per partition) -- the no-pointer case below reuses
+            # _star_pool_and_reduce()'s own equivalent guard instead,
+            # since it is really the same "list everything, unreduced"
+            # case once there is no pointer.
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not yet support combining "
                 "':all()' grouping with a name_three content accessor -- "
                 "resolve the grouped runs on their own first."
+            )
+        if pointer is None:
+            return self._star_pool_and_reduce(
+                [rh for rh, _ in partitioned],
+                None,
+                identity,
+                match_all,
+                range_bounds,
+                accessor,
             )
         groups: dict = {}
         for rh, key in partitioned:

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -634,6 +634,61 @@ class TestStarTraversalFlatten:
             _star_finder("$*.csvpaths.:last().0").query()
 
 
+class TestStarTraversalPoolNoPointerIsOptional:
+    # a pointer is now optional in POOL/FLATTEN mode too (settled
+    # 2026-08-19) -- previously the one place csvpaths' own star
+    # traversal still required one unconditionally, an inconsistency
+    # with GROUP mode's own no-pointer precedent (which already listed
+    # everything per group, unreduced) and with RESULTS'/
+    # FilesReferenceFinder3's star traversal (neither ever requires
+    # one). Absence means every candidate across every group comes
+    # back, unreduced. Unlike RESULTS/FILES, csvpaths' name_one always
+    # requires SOME function as its sole path segment (no bare/literal-
+    # path-only shape exists here at all, confirmed live: "$*.csvpaths."
+    # with nothing after does not even parse) -- so POOL-mode-no-
+    # pointer is only reachable via a field accessor or ':having()'
+    # occupying that slot, not a truly empty reference.
+    def test_no_pointer_with_a_field_accessor_is_poolable(self):
+        by_name = {
+            "alpha": [
+                {
+                    "group_file_path": "named_paths/alpha/group.csvpath",
+                    "uuid": "a-v1",
+                    "time": "2026-01-01T00:00:00+00:00",
+                    "named_paths_name": "alpha",
+                }
+            ],
+            "beta": [
+                {
+                    "group_file_path": "named_paths/beta/group.csvpath",
+                    "uuid": "b-v1",
+                    "time": "2026-01-03T00:00:00+00:00",
+                    "named_paths_name": "beta",
+                }
+            ],
+        }
+        results = _finder(
+            "$*.csvpaths.:named_paths_name()", by_name=by_name
+        ).resolve()
+        assert sorted((r.uuid, r.data) for r in results.results) == [
+            ("a-v1", "alpha"),
+            ("b-v1", "beta"),
+        ]
+
+    def test_previously_masked_unrecognized_function_now_raises(self):
+        # a real, previously-latent bug this same fix exposed and
+        # closed: the old check only ever rejected ":manifest()"/
+        # ':from()'/':to()' BY NAME (a blacklist) -- any other
+        # unrecognized function (e.g. ':definition()', confirmed via
+        # TestGlobalLoadsLedger's own test) silently fell through
+        # unrejected once "no pointer" stopped forcing a raise for an
+        # unrelated reason. Now whitelist-based (only a pointer/':all()'
+        # /':having()'/a field accessor are exempted), closing that gap
+        # generally, not just for the one name already known about.
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.csvpaths.:groups()").query()
+
+
 class TestStarTraversalFieldAccessor:
     # closes the gap ReferenceExpression3 needed -- a registered field-
     # accessor function can now ride alongside the pointer in '*'
@@ -886,17 +941,17 @@ class TestStarTraversalHaving:
         ).query()
         assert results.results == []
 
-    def test_bare_having_alone_still_requires_a_pointer_or_all(self):
-        # deliberately unchanged -- a bare ':having()' with no pointer
-        # and no ':all()' does not get a new "unreduced flatten" meaning
-        # of its own; it falls into the same pre-existing "requires a
-        # pointer" rule flatten mode already enforces for a plain bare
-        # pointer, consistent with FLATTEN never having an "unreduced"
-        # form for csvpaths' own star traversal.
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$*.csvpaths.:having(\"orders\")", by_name=self.HAVING_BY_NAME
-            ).query()
+    def test_bare_having_alone_with_no_pointer_lists_matching_versions(self):
+        # a pointer is optional everywhere in csvpaths' star traversal
+        # now (settled 2026-08-19, closing the one place it was still
+        # required unconditionally) -- a bare ':having()' with no
+        # pointer and no ':all()' means "every matching version, pooled
+        # across every group, unreduced," the same POOL-mode-no-pointer
+        # meaning a bare pointer-less reference now has too.
+        results = _finder(
+            "$*.csvpaths.:having(\"orders\")", by_name=self.HAVING_BY_NAME
+        ).query()
+        assert results.uuids == ["a-v1"]
 
 
 class TestDefinitionFunction:

--- a/tests/references/test_reference_expression_3.py
+++ b/tests/references/test_reference_expression_3.py
@@ -227,26 +227,28 @@ class TestConstruction:
 
 #
 # ---- end-to-end, real Finder plumbing -- David's own "orders" example
-# (references_notes/notes/reference_expressions_notes.txt), using literal
-# (non-'*') root_major on both sides, via real on-disk fixtures matching
-# test_results_reference_finder_3.py's own established pattern.
+# (references_notes/notes/reference_expressions_notes.txt).
 #
-# UPDATED 2026-08-18 (PR #253): '*' traversal combined with a BARE field
-# accessor (riding alongside a plain pointer or ':all()') now works for
-# both CsvpathsReferenceFinder3 and ResultsReferenceFinder3 -- see
-# TestStarTraversalPlusFieldAccessorNowWorks below. The "orders" example
-# ITSELF still cannot be rewritten to use real '*' traversal on either
-# side, though, because it specifically needs a field accessor combined
-# with ':having()' (CSVPATHS' right side -- "every group with an
-# 'orders' statement") or ':flatten()' (RESULTS' left side -- "every
-# run, any depth") -- neither of those is a bare pointer/':all()', and
-# neither is supported in '*' traversal yet (confirmed live -- see
-# TestHavingAndFlattenPlusStarTraversalStillNotSupported below). #253
-# only closed the narrower "plain field accessor alongside a pointer/
-# :all()" gap it was scoped to, not this one. Sub-expressions (nested
-# ReferenceExpression3, UNION-ing two literal per-group queries) still
-# stand in for "search every group" here -- exactly the shape a caller
-# CAN write today when the candidate group names are already known.
+# UPDATED 2026-08-19 (PR #254, all commits): both sides now use REAL '*'
+# traversal, single plain reference strings, no sub-expression workaround
+# needed anymore. Three '*'-traversal gaps had to close, in order, before
+# this was reachable:
+#   1. (#253) a bare field accessor riding alongside a pointer/':all()'.
+#   2. (#254) ':having()' (CSVPATHS)/':flatten()' (RESULTS) combined with
+#      traversal at all -- CSVPATHS' right side needs :having(), RESULTS'
+#      left side needs :flatten(), neither was recognized before this.
+#   3. (#254) a pointer became OPTIONAL in every RESULTS '*'-traversal
+#      shape (previously always required) -- RESULTS' own left side
+#      needs "every run, unreduced," which only exists without a
+#      pointer. Confirmed against FilesReferenceFinder3 (never requires
+#      one, any mode) and RESULTS' own literal-root precedent (same)
+#      before making this change -- CsvpathsReferenceFinder3's own
+#      narrower, asymmetric precedent (pointer required in POOL mode,
+#      optional only in GROUP/':all()') was NOT the target; CSVPATHS'
+#      right side already worked via its OWN existing ':all()'-no-
+#      pointer precedent, unaffected by this RESULTS-only change.
+# _left_side/_right_side below were previously each a UNION sub-
+# expression of two literal per-group queries -- now single strings.
 #
 GROUPA_MANIFEST = [
     {
@@ -356,25 +358,23 @@ def orders_archive(tmp_path):
     return _FakeCsvPaths(str(archive), {"groupa": GROUPA_MANIFEST, "groupb": GROUPB_MANIFEST})
 
 
-def _left_side(csvpaths) -> ReferenceExpression3:
-    # "every run" -- UNION of the two known groups' own runs.
-    return ReferenceExpression3(
-        left="$groupa.results.:flatten():named_paths_name()",
-        op=ReferenceExpression3.UNION,
-        right="$groupb.results.:flatten():named_paths_name()",
-        csvpaths=csvpaths,
-    )
+def _left_side(csvpaths) -> str:
+    # "every run" -- a single real '*' traversal reference now (updated
+    # 2026-08-19): ':flatten()' (any depth, POOL) with no pointer lists
+    # every matched run across every group, unreduced -- both the
+    # ':flatten()'-combined-with-traversal gap and the pointer-optional
+    # gap had to close first (see this module's own docstring above).
+    return "$*.results.:flatten():named_paths_name()"
 
 
-def _right_side(csvpaths) -> ReferenceExpression3:
-    # "every group with an 'orders' statement" -- UNION of the two known
-    # groups' own :having() checks.
-    return ReferenceExpression3(
-        left='$groupa.csvpaths.:having("orders"):named_paths_name()',
-        op=ReferenceExpression3.UNION,
-        right='$groupb.csvpaths.:having("orders"):named_paths_name()',
-        csvpaths=csvpaths,
-    )
+def _right_side(csvpaths) -> str:
+    # "every group with an 'orders' statement" -- a single real '*'
+    # traversal reference now (updated 2026-08-19): ':having("orders")'
+    # filters, ':all()' with no pointer lists every matching version per
+    # group, unreduced -- CSVPATHS' own ':all()'-no-pointer precedent
+    # already supported this once ':having()' itself was recognized in
+    # traversal (#254), no further CSVPATHS change was needed.
+    return '$*.csvpaths.:having("orders"):all():named_paths_name()'
 
 
 class TestOrdersExampleEndToEnd:
@@ -518,33 +518,35 @@ class TestStarTraversalPlusFieldAccessorNowWorks:
         assert {r.data for r in result.results} == {"groupa", "groupb"}
 
 
-class TestHavingAndFlattenPlusStarTraversalStillNotSupported:
-    # a separate, narrower, still-open gap -- NOT fixed by #253, and not
-    # the same thing TestStarTraversalPlusFieldAccessorNowWorks above
-    # proves works now. #253 only exempted a field accessor riding
-    # alongside a bare pointer/':all()' from the '*'-traversal guard;
-    # ':having()' (CSVPATHS) and ':flatten()' (RESULTS) are neither of
-    # those, and neither is recognized by _query_star_traversal at all --
-    # confirmed live before writing these: the CSVPATHS case now raises
-    # "requires a pointer... use :all() instead" (having is silently
-    # neither a pointer nor :all(), so it falls through to that
-    # unrelated check) and the RESULTS case still raises its own
-    # explicit ":flatten() combined with '*' traversal" rejection. This
-    # is exactly why the "orders" example above still needs the sub-
-    # expression workaround on both sides, even after #253.
-    def test_csvpaths_having_combined_with_traversal_still_raises(
+class TestHavingAndFlattenPlusStarTraversalNowWork:
+    # PR #254 (2026-08-19, full run) closed this gap in stages: first
+    # recognizing ':having()' (CSVPATHS)/':flatten()' (RESULTS) in '*'
+    # traversal at all, then making a pointer OPTIONAL in every RESULTS
+    # shape (RESULTS' own left side needs "every run, unreduced," which
+    # only a missing pointer gives -- CSVPATHS' own ':all()' already had
+    # its own no-pointer precedent, unaffected). This class used to
+    # assert both raised; confirmed live before rewriting that neither
+    # does anymore, then replaced with positive tests -- proven here at
+    # the ReferenceExpression3 level (plain reference strings, not the
+    # Finder classes directly), same integration point
+    # TestStarTraversalPlusFieldAccessorNowWorks above proves.
+    def test_csvpaths_having_combined_with_traversal_now_works(
         self, orders_archive
     ):
         expr = ReferenceExpression3(
-            left="$*.csvpaths.:having(\"orders\"):named_paths_name()",
+            left="$*.csvpaths.:having(\"orders\"):all():named_paths_name()",
             op=ReferenceExpression3.UNION,
             right="$groupa.csvpaths.:having(\"orders\"):named_paths_name()",
             csvpaths=orders_archive,
         )
-        with pytest.raises(ReferenceException3):
-            expr.resolve()
+        result = expr.resolve()
+        # right's groupa item is IDENTICAL to left's own groupa item
+        # (same path/uuid/resolved data) -- UNION's dedup collapses the
+        # duplicate, leaving one groupa (from either side) plus left's
+        # own groupb, not three/two raw items pooled naively.
+        assert sorted(r.data for r in result.results) == ["groupa", "groupb"]
 
-    def test_results_flatten_combined_with_traversal_still_raises(
+    def test_results_flatten_combined_with_traversal_now_works(
         self, orders_archive
     ):
         expr = ReferenceExpression3(
@@ -553,5 +555,14 @@ class TestHavingAndFlattenPlusStarTraversalStillNotSupported:
             right="$groupa.results.:flatten():named_paths_name()",
             csvpaths=orders_archive,
         )
-        with pytest.raises(ReferenceException3):
-            expr.resolve()
+        result = expr.resolve()
+        # right's a1/a2 are IDENTICAL to left's own a1/a2 (same run
+        # dir/uuid/resolved data) -- UNION's dedup collapses the
+        # duplicates, leaving all 5 distinct runs once each, not 6.
+        assert sorted(r.uuid for r in result.results) == [
+            "a1",
+            "a2",
+            "b1",
+            "b2",
+            "b3",
+        ]

--- a/tests/references/test_reference_expression_3.py
+++ b/tests/references/test_reference_expression_3.py
@@ -1,0 +1,497 @@
+import json
+import os
+
+import pytest
+
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+from csvpath.references.reference_expression_3 import ReferenceExpression3
+from csvpath.references.reference_results_3 import ReferenceResult3, ReferenceResults3
+
+
+#
+# ---- pure operation-logic tests (synthetic ReferenceResults3, no real
+# Finders) -- fast, and exercise the set-operation semantics themselves in
+# isolation from any parsing/dispatch concerns.
+#
+class TestUnion:
+    def test_concatenates_both_sides(self):
+        left = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data="a")]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p2", uuid="u2", data="b")]
+        )
+        result = ReferenceExpression3._union(left, right)
+        assert result.files == ["p1", "p2"]
+
+    def test_collapses_true_duplicates(self):
+        item = ReferenceResult3(path="p1", uuid="u1", data="a")
+        left = ReferenceResults3(results=[item])
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data="a")]
+        )
+        result = ReferenceExpression3._union(left, right)
+        assert len(result) == 1
+
+    def test_does_not_collapse_items_that_merely_share_a_key(self):
+        # UNION never looks at .data as a key at all -- two DIFFERENT
+        # items (different path/uuid) with the same .data value both
+        # survive, same as if .data were not even resolved.
+        left = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data="same")]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p2", uuid="u2", data="same")]
+        )
+        result = ReferenceExpression3._union(left, right)
+        assert len(result) == 2
+
+    def test_both_sides_empty_gives_empty(self):
+        result = ReferenceExpression3._union(ReferenceResults3(), ReferenceResults3())
+        assert result.results == []
+
+
+class TestIntersect:
+    def test_keeps_every_matching_left_item_not_just_one_per_key(self):
+        # the actual bug caught while building this: an earlier draft
+        # deduplicated the LEFT side by key before filtering, which
+        # silently collapsed multiple runs sharing one group name down
+        # to one. "give me all the runs where the group had 'orders'"
+        # must return every matching run, not one exemplar per group.
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="a-run2", uuid="u2", data="groupA"),
+                ReferenceResult3(path="b-run1", uuid="u3", data="groupB"),
+                ReferenceResult3(path="b-run2", uuid="u4", data="groupB"),
+                ReferenceResult3(path="b-run3", uuid="u5", data="groupB"),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA"),
+                ReferenceResult3(path="groupB/g.csvpath", uuid="gvb", data="groupB"),
+            ]
+        )
+        result = ReferenceExpression3._intersect(left, right)
+        assert result.files == ["a-run1", "a-run2", "b-run1", "b-run2", "b-run3"]
+
+    def test_only_keeps_left_items_whose_key_matches(self):
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="b-run1", uuid="u3", data="groupB"),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        result = ReferenceExpression3._intersect(left, right)
+        assert result.files == ["a-run1"]
+
+    def test_no_matches_gives_empty(self):
+        left = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data="x")]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p2", uuid="u2", data="y")]
+        )
+        assert ReferenceExpression3._intersect(left, right).results == []
+
+    def test_none_keyed_left_items_never_survive(self):
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="x-run1", uuid="u9", data=None),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        result = ReferenceExpression3._intersect(left, right)
+        assert result.files == ["a-run1"]
+
+    def test_true_duplicate_left_items_collapse_to_one(self):
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        assert len(ReferenceExpression3._intersect(left, right)) == 1
+
+    def test_unhashable_left_key_raises(self):
+        left = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data=["not", "hashable"])]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p2", uuid="u2", data="x")]
+        )
+        with pytest.raises(ReferenceException3):
+            ReferenceExpression3._intersect(left, right)
+
+    def test_unhashable_right_key_raises(self):
+        left = ReferenceResults3(
+            results=[ReferenceResult3(path="p1", uuid="u1", data="x")]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="p2", uuid="u2", data={"not": "hashable"})]
+        )
+        with pytest.raises(ReferenceException3):
+            ReferenceExpression3._intersect(left, right)
+
+
+class TestSubtract:
+    def test_removes_left_items_whose_key_matches_the_right(self):
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="b-run1", uuid="u3", data="groupB"),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        result = ReferenceExpression3._subtract(left, right)
+        assert result.files == ["b-run1"]
+
+    def test_none_keyed_left_items_always_survive(self):
+        # a None key can never be matched away -- it never establishes
+        # a match in the first place.
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="x-run1", uuid="u9", data=None),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        result = ReferenceExpression3._subtract(left, right)
+        assert result.files == ["x-run1"]
+
+    def test_removes_every_matching_left_item_not_just_one(self):
+        left = ReferenceResults3(
+            results=[
+                ReferenceResult3(path="a-run1", uuid="u1", data="groupA"),
+                ReferenceResult3(path="a-run2", uuid="u2", data="groupA"),
+                ReferenceResult3(path="b-run1", uuid="u3", data="groupB"),
+            ]
+        )
+        right = ReferenceResults3(
+            results=[ReferenceResult3(path="groupA/g.csvpath", uuid="gva", data="groupA")]
+        )
+        result = ReferenceExpression3._subtract(left, right)
+        assert result.files == ["b-run1"]
+
+
+#
+# ---- constructor validation
+#
+class TestConstruction:
+    def test_rejects_none_or_empty_left(self):
+        with pytest.raises(ValueError):
+            ReferenceExpression3(
+                left="", op=ReferenceExpression3.UNION, right="$acme.results.:last()",
+                csvpaths=object(),
+            )
+
+    def test_rejects_none_or_empty_right(self):
+        with pytest.raises(ValueError):
+            ReferenceExpression3(
+                left="$acme.results.:last()", op=ReferenceExpression3.UNION, right="",
+                csvpaths=object(),
+            )
+
+    def test_rejects_unrecognized_op(self):
+        with pytest.raises(ValueError):
+            ReferenceExpression3(
+                left="$acme.results.:last()",
+                op="xor",
+                right="$acme.results.:last()",
+                csvpaths=object(),
+            )
+
+    def test_rejects_none_csvpaths(self):
+        with pytest.raises(ValueError):
+            ReferenceExpression3(
+                left="$acme.results.:last()",
+                op=ReferenceExpression3.UNION,
+                right="$acme.results.:last()",
+                csvpaths=None,
+            )
+
+
+#
+# ---- end-to-end, real Finder plumbing -- David's own "orders" example
+# (references_notes/notes/reference_expressions_notes.txt), using literal
+# (non-'*') root_major on both sides, via real on-disk fixtures matching
+# test_results_reference_finder_3.py's own established pattern. '*'
+# traversal combined with a trailing field accessor is not supported by
+# either CsvpathsReferenceFinder3 or ResultsReferenceFinder3 today
+# (confirmed via direct testing while building this -- see
+# TestStarTraversalPlusFieldAccessorIsNotYetSupported below) -- a real,
+# separate limitation on the Finders themselves, not something
+# ReferenceExpression3 needs to work around. Sub-expressions (nested
+# ReferenceExpression3, UNION-ing two literal per-group queries) stand in
+# for "search every group" here instead -- exactly the shape a caller CAN
+# write today when the candidate group names are already known.
+#
+GROUPA_MANIFEST = [
+    {
+        "group_file_path": "named_paths/groupa/group.csvpath",
+        "uuid": "gva",
+        "named_paths": ["stmt orders text"],
+        "named_paths_identities": ["orders"],
+        "named_paths_name": "groupa",
+    }
+]
+GROUPB_MANIFEST = [
+    {
+        "group_file_path": "named_paths/groupb/group.csvpath",
+        "uuid": "gvb",
+        "named_paths": ["stmt orders text"],
+        "named_paths_identities": ["orders"],
+        "named_paths_name": "groupb",
+    }
+]
+
+
+class _FakePathsManager:
+    def __init__(self, by_name):
+        self._by_name = by_name
+
+    def get_manifest_for_name(self, name):
+        return self._by_name.get(name, [])
+
+    def named_paths_home(self, name):
+        return f"named_paths/{name}"
+
+    @property
+    def named_paths_names(self):
+        return list(self._by_name.keys())
+
+    @property
+    def paths_root_manifest(self):
+        return []
+
+
+class _FakeResultsManager:
+    def __init__(self, archive: str):
+        self._archive = archive
+
+    def get_named_results_home(self, name):
+        return os.path.join(self._archive, name)
+
+    @property
+    def results_root_manifest(self):
+        with open(os.path.join(self._archive, "manifest.json")) as f:
+            return json.load(f)
+
+
+class _FakeConfig:
+    def __init__(self, archive: str):
+        self._archive = archive
+        self.inputs_csvpaths_path = None
+
+    def get(self, *, section, name):
+        return self._archive
+
+
+class _FakeCsvPaths:
+    def __init__(self, archive: str, paths_by_name: dict):
+        self.paths_manager = _FakePathsManager(paths_by_name)
+        self.results_manager = _FakeResultsManager(archive)
+        self.config = _FakeConfig(archive)
+
+
+def _write_json(path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_run(base, run_name: str, run_uuid: str, group_name: str) -> str:
+    run_dir = base / run_name
+    _write_json(
+        run_dir / "manifest.json",
+        {"run_uuid": run_uuid, "named_paths_name": group_name},
+    )
+    return str(run_dir)
+
+
+def _write_archive_manifest_multi(archive, groups: dict) -> None:
+    entries = []
+    for group, run_homes in groups.items():
+        entries.extend({"named_paths_name": group, "run_home": rh} for rh in run_homes)
+    _write_json(archive / "manifest.json", entries)
+
+
+@pytest.fixture
+def orders_archive(tmp_path):
+    # group A: 2 runs, group B: 3 runs, both groups have an "orders"
+    # csvpath statement in their current version -- David's own worked
+    # example (references_notes/notes/reference_expressions_notes.txt).
+    archive = tmp_path / "archive"
+    a_runs = [
+        _make_run(archive / "groupa", "2026-01-01_00-00-00", "a1", "groupa"),
+        _make_run(archive / "groupa", "2026-01-02_00-00-00", "a2", "groupa"),
+    ]
+    b_runs = [
+        _make_run(archive / "groupb", "2026-01-01_00-00-00", "b1", "groupb"),
+        _make_run(archive / "groupb", "2026-01-02_00-00-00", "b2", "groupb"),
+        _make_run(archive / "groupb", "2026-01-03_00-00-00", "b3", "groupb"),
+    ]
+    _write_archive_manifest_multi(archive, {"groupa": a_runs, "groupb": b_runs})
+    return _FakeCsvPaths(str(archive), {"groupa": GROUPA_MANIFEST, "groupb": GROUPB_MANIFEST})
+
+
+def _left_side(csvpaths) -> ReferenceExpression3:
+    # "every run" -- UNION of the two known groups' own runs.
+    return ReferenceExpression3(
+        left="$groupa.results.:flatten():named_paths_name()",
+        op=ReferenceExpression3.UNION,
+        right="$groupb.results.:flatten():named_paths_name()",
+        csvpaths=csvpaths,
+    )
+
+
+def _right_side(csvpaths) -> ReferenceExpression3:
+    # "every group with an 'orders' statement" -- UNION of the two known
+    # groups' own :having() checks.
+    return ReferenceExpression3(
+        left='$groupa.csvpaths.:having("orders"):named_paths_name()',
+        op=ReferenceExpression3.UNION,
+        right='$groupb.csvpaths.:having("orders"):named_paths_name()',
+        csvpaths=csvpaths,
+    )
+
+
+class TestOrdersExampleEndToEnd:
+    def test_both_groups_have_orders_all_five_runs_come_back(self, orders_archive):
+        expr = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.INTERSECT,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        assert sorted(r.uuid for r in result.results) == ["a1", "a2", "b1", "b2", "b3"]
+
+    def test_only_one_group_has_orders_only_its_runs_come_back(self, orders_archive):
+        # groupB's version no longer has "orders" -- :having() only
+        # matches groupA now.
+        orders_archive.paths_manager._by_name["groupb"] = [
+            {
+                "group_file_path": "named_paths/groupb/group.csvpath",
+                "uuid": "gvb",
+                "named_paths": ["stmt other text"],
+                "named_paths_identities": ["other"],
+                "named_paths_name": "groupb",
+            }
+        ]
+        expr = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.INTERSECT,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        assert sorted(r.uuid for r in result.results) == ["a1", "a2"]
+
+    def test_neither_group_has_orders_no_runs_come_back(self, orders_archive):
+        for name in ("groupa", "groupb"):
+            orders_archive.paths_manager._by_name[name] = [
+                {
+                    "group_file_path": f"named_paths/{name}/group.csvpath",
+                    "uuid": f"gv-{name}",
+                    "named_paths": ["stmt other text"],
+                    "named_paths_identities": ["other"],
+                    "named_paths_name": name,
+                }
+            ]
+        expr = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.INTERSECT,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        assert result.results == []
+
+    def test_union_of_runs_and_groups_matches_the_documented_7_6_5(self, orders_archive):
+        # the doc's own worked UNION variants -- 7 with both groups
+        # matching, dropping to 6 and then 5 as groups stop matching.
+        expr = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.UNION,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        assert len(expr.resolve()) == 7
+
+        orders_archive.paths_manager._by_name["groupb"] = [
+            {
+                "group_file_path": "named_paths/groupb/group.csvpath",
+                "uuid": "gvb",
+                "named_paths": ["stmt other text"],
+                "named_paths_identities": ["other"],
+                "named_paths_name": "groupb",
+            }
+        ]
+        expr2 = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.UNION,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        assert len(expr2.resolve()) == 6
+
+        orders_archive.paths_manager._by_name["groupa"] = [
+            {
+                "group_file_path": "named_paths/groupa/group.csvpath",
+                "uuid": "gva",
+                "named_paths": ["stmt other text"],
+                "named_paths_identities": ["other"],
+                "named_paths_name": "groupa",
+            }
+        ]
+        expr3 = ReferenceExpression3(
+            left=_left_side(orders_archive),
+            op=ReferenceExpression3.UNION,
+            right=_right_side(orders_archive),
+            csvpaths=orders_archive,
+        )
+        assert len(expr3.resolve()) == 5
+
+
+class TestStarTraversalPlusFieldAccessorIsNotYetSupported:
+    # a real, pre-existing limitation on BOTH Finders (not something
+    # ReferenceExpression3 introduces or needs to fix) -- confirmed via
+    # direct testing while building this class: neither
+    # CsvpathsReferenceFinder3 nor ResultsReferenceFinder3 support '*'
+    # traversal combined with a trailing field accessor yet, which blocks
+    # the most literal phrasing of "every group"/"every run" without
+    # already knowing the candidate names -- see the module docstring
+    # above for how the "orders" tests work around it today.
+    def test_csvpaths_star_traversal_with_field_accessor_raises(self, orders_archive):
+        expr = ReferenceExpression3(
+            left="$*.csvpaths.:having(\"orders\"):named_paths_name()",
+            op=ReferenceExpression3.UNION,
+            right="$groupa.csvpaths.:having(\"orders\"):named_paths_name()",
+            csvpaths=orders_archive,
+        )
+        with pytest.raises(ReferenceException3):
+            expr.resolve()
+
+    def test_results_star_traversal_with_field_accessor_raises(self, orders_archive):
+        expr = ReferenceExpression3(
+            left="$*.results.:flatten():named_paths_name()",
+            op=ReferenceExpression3.UNION,
+            right="$groupa.results.:flatten():named_paths_name()",
+            csvpaths=orders_archive,
+        )
+        with pytest.raises(ReferenceException3):
+            expr.resolve()

--- a/tests/references/test_reference_expression_3.py
+++ b/tests/references/test_reference_expression_3.py
@@ -229,16 +229,24 @@ class TestConstruction:
 # ---- end-to-end, real Finder plumbing -- David's own "orders" example
 # (references_notes/notes/reference_expressions_notes.txt), using literal
 # (non-'*') root_major on both sides, via real on-disk fixtures matching
-# test_results_reference_finder_3.py's own established pattern. '*'
-# traversal combined with a trailing field accessor is not supported by
-# either CsvpathsReferenceFinder3 or ResultsReferenceFinder3 today
-# (confirmed via direct testing while building this -- see
-# TestStarTraversalPlusFieldAccessorIsNotYetSupported below) -- a real,
-# separate limitation on the Finders themselves, not something
-# ReferenceExpression3 needs to work around. Sub-expressions (nested
-# ReferenceExpression3, UNION-ing two literal per-group queries) stand in
-# for "search every group" here instead -- exactly the shape a caller CAN
-# write today when the candidate group names are already known.
+# test_results_reference_finder_3.py's own established pattern.
+#
+# UPDATED 2026-08-18 (PR #253): '*' traversal combined with a BARE field
+# accessor (riding alongside a plain pointer or ':all()') now works for
+# both CsvpathsReferenceFinder3 and ResultsReferenceFinder3 -- see
+# TestStarTraversalPlusFieldAccessorNowWorks below. The "orders" example
+# ITSELF still cannot be rewritten to use real '*' traversal on either
+# side, though, because it specifically needs a field accessor combined
+# with ':having()' (CSVPATHS' right side -- "every group with an
+# 'orders' statement") or ':flatten()' (RESULTS' left side -- "every
+# run, any depth") -- neither of those is a bare pointer/':all()', and
+# neither is supported in '*' traversal yet (confirmed live -- see
+# TestHavingAndFlattenPlusStarTraversalStillNotSupported below). #253
+# only closed the narrower "plain field accessor alongside a pointer/
+# :all()" gap it was scoped to, not this one. Sub-expressions (nested
+# ReferenceExpression3, UNION-ing two literal per-group queries) still
+# stand in for "search every group" here -- exactly the shape a caller
+# CAN write today when the candidate group names are already known.
 #
 GROUPA_MANIFEST = [
     {
@@ -467,16 +475,66 @@ class TestOrdersExampleEndToEnd:
         assert len(expr3.resolve()) == 5
 
 
-class TestStarTraversalPlusFieldAccessorIsNotYetSupported:
-    # a real, pre-existing limitation on BOTH Finders (not something
-    # ReferenceExpression3 introduces or needs to fix) -- confirmed via
-    # direct testing while building this class: neither
-    # CsvpathsReferenceFinder3 nor ResultsReferenceFinder3 support '*'
-    # traversal combined with a trailing field accessor yet, which blocks
-    # the most literal phrasing of "every group"/"every run" without
-    # already knowing the candidate names -- see the module docstring
-    # above for how the "orders" tests work around it today.
-    def test_csvpaths_star_traversal_with_field_accessor_raises(self, orders_archive):
+class TestStarTraversalPlusFieldAccessorNowWorks:
+    # PR #253 (2026-08-18) fixed the Finder-level gap this class used to
+    # document as unsupported: a run/version-level field accessor can now
+    # ride alongside a bare pointer or ':all()' in '*' traversal, for
+    # both CsvpathsReferenceFinder3 (via the new _group_manifest_entry()
+    # helper) and ResultsReferenceFinder3 (already group-independent once
+    # the guard was loosened). Already covered directly at the Finder
+    # level in test_csvpaths_reference_finder_3.py/
+    # test_results_reference_finder_3.py -- proven here too since this is
+    # the actual integration point ReferenceExpression3 needs: a plain
+    # reference STRING with root_major='*' now resolves successfully all
+    # the way through ReferenceFinderFactory3 -> the Finder -> resolve(),
+    # not just when hand-built directly against the Finder class.
+    def test_csvpaths_star_traversal_with_field_accessor_resolves(
+        self, orders_archive
+    ):
+        expr = ReferenceExpression3(
+            left="$*.csvpaths.:all():named_paths_name()",
+            op=ReferenceExpression3.UNION,
+            right="$*.csvpaths.:all():named_paths_name()",
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        assert sorted(r.data for r in result.results) == ["groupa", "groupb"]
+
+    def test_results_star_traversal_with_field_accessor_resolves(
+        self, orders_archive
+    ):
+        expr = ReferenceExpression3(
+            left="$*.results.:last():named_paths_name()",
+            op=ReferenceExpression3.UNION,
+            right="$groupa.results.:flatten():named_paths_name()",
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        # groupB's b3 (2026-01-03) is the true global-latest run -- '*'
+        # traversal pools/sorts across both groups by real timestamp, so
+        # this only comes back correctly if the star-rooted side above
+        # actually resolved through traversal rather than raising.
+        assert "b3" in {r.uuid for r in result.results}
+        assert {r.data for r in result.results} == {"groupa", "groupb"}
+
+
+class TestHavingAndFlattenPlusStarTraversalStillNotSupported:
+    # a separate, narrower, still-open gap -- NOT fixed by #253, and not
+    # the same thing TestStarTraversalPlusFieldAccessorNowWorks above
+    # proves works now. #253 only exempted a field accessor riding
+    # alongside a bare pointer/':all()' from the '*'-traversal guard;
+    # ':having()' (CSVPATHS) and ':flatten()' (RESULTS) are neither of
+    # those, and neither is recognized by _query_star_traversal at all --
+    # confirmed live before writing these: the CSVPATHS case now raises
+    # "requires a pointer... use :all() instead" (having is silently
+    # neither a pointer nor :all(), so it falls through to that
+    # unrelated check) and the RESULTS case still raises its own
+    # explicit ":flatten() combined with '*' traversal" rejection. This
+    # is exactly why the "orders" example above still needs the sub-
+    # expression workaround on both sides, even after #253.
+    def test_csvpaths_having_combined_with_traversal_still_raises(
+        self, orders_archive
+    ):
         expr = ReferenceExpression3(
             left="$*.csvpaths.:having(\"orders\"):named_paths_name()",
             op=ReferenceExpression3.UNION,
@@ -486,7 +544,9 @@ class TestStarTraversalPlusFieldAccessorIsNotYetSupported:
         with pytest.raises(ReferenceException3):
             expr.resolve()
 
-    def test_results_star_traversal_with_field_accessor_raises(self, orders_archive):
+    def test_results_flatten_combined_with_traversal_still_raises(
+        self, orders_archive
+    ):
         expr = ReferenceExpression3(
             left="$*.results.:flatten():named_paths_name()",
             op=ReferenceExpression3.UNION,

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1913,19 +1913,42 @@ class TestStarTraversal:
         results = _finder("$*.results.:index(1)", two_group_archive).query()
         assert results.results[0].uuid == "acme-run2-uuid"
 
-    def test_bare_all_with_no_pointer_still_requires_a_pointer(
+    def test_bare_all_with_no_pointer_gives_empty_on_flat_runs(
         self, two_group_archive
     ):
-        # ':all()' grouping DOES have a home in star traversal now (see
-        # TestAllGroupingStarTraversal) -- unlike ':manifest()'/
-        # name_three, this was never a "no meaning exists" restriction.
-        # What still raises is the SAME "no pointer" rule ':flatten()'
-        # is also held to in traversal mode -- a bare ':all()' with no
-        # pointer does not get an "unreduced, list everything" meaning
-        # of its own here, consistent with FLATTEN mode's own no-
-        # pointer restriction in this same method.
-        with pytest.raises(ReferenceException3):
-            _finder("$*.results.:all()", two_group_archive).query()
+        # a pointer is optional everywhere in star traversal now
+        # (settled 2026-08-19, matching RESULTS' own literal-root
+        # precedent and FilesReferenceFinder3, neither of which ever
+        # required one) -- absence means "every matched run, unreduced"
+        # rather than an error. two_group_archive's runs are all flat
+        # (zero-level), so ':all()' (which requires exactly one level)
+        # correctly matches nothing here -- empty, not a raise.
+        results = _finder("$*.results.:all()", two_group_archive).query()
+        assert results.results == []
+
+    def test_bare_all_with_no_pointer_lists_every_one_level_run(
+        self, tmp_path
+    ):
+        acme_x = _make_run(
+            tmp_path / "acme" / "east", "2026-01-01_00-00-00", "acme-east", {}
+        )
+        acme_y = _make_run(
+            tmp_path / "acme" / "west", "2026-01-02_00-00-00", "acme-west", {}
+        )
+        widgets_x = _make_run(
+            tmp_path / "widgets" / "east",
+            "2026-01-03_00-00-00",
+            "widgets-east",
+            {},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_x, acme_y], "widgets": [widgets_x]}
+        )
+        results = _finder("$*.results.:all()", str(tmp_path)).query()
+        # every one-level run across every group, unreduced -- NOT one
+        # per (group, template) partition, since grouping only matters
+        # once there is a pointer to reduce a partition to one.
+        assert sorted(results.uuids) == ["acme-east", "acme-west", "widgets-east"]
 
     def test_name_three_combined_with_traversal_now_works(self, tmp_path):
         # closes the name_three gap (2026-08-19) -- _results_for_run()
@@ -2193,6 +2216,139 @@ class TestStarTraversalPathNarrowingAndNameThree:
             "$*.results.:flatten():last().invoices", str(tmp_path)
         ).query()
         assert results.results[0].uuid == "acme-invoices"
+
+
+class TestStarTraversalPointerIsOptional:
+    # a pointer is optional in EVERY '*' traversal shape now (settled
+    # 2026-08-19) -- absence means every matched run comes back,
+    # unreduced, mirroring RESULTS' own literal-root precedent (no
+    # shape there ever required one) and FilesReferenceFinder3's star
+    # traversal (also never requires one, in any of its four modes).
+    # CsvpathsReferenceFinder3's own narrower precedent (pointer
+    # required in POOL/flatten mode, optional only in GROUP/':all()')
+    # was deliberately NOT copied -- confirmed via reading its code
+    # that it is the outlier among the three, not the target.
+    def test_zero_level_bare_with_no_pointer_lists_every_flat_run(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "acme-run", {}
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets", "2026-01-02_00-00-00", "widgets-run", {}
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        # ':home()' is the only legal spelling of "bare, zero-level,
+        # nothing else" -- a totally empty name_one ("$*.results.") is
+        # not valid grammar (confirmed live: Lark rejects it outright).
+        results = _finder("$*.results.:home()", str(tmp_path)).query()
+        assert sorted(results.uuids) == ["acme-run", "widgets-run"]
+
+    def test_prefixed_flatten_with_no_pointer_lists_everything_beyond_prefix(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme" / "beta" / "x",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets" / "beta" / "y" / "z",
+            "2026-01-02_00-00-00",
+            "widgets-run",
+            {},
+        )
+        other_run = _make_run(
+            tmp_path / "widgets" / "gamma", "2026-01-03_00-00-00", "other-run", {}
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {"acme": [acme_run], "widgets": [widgets_run, other_run]},
+        )
+        results = _finder("$*.results.beta/:flatten()", str(tmp_path)).query()
+        assert sorted(results.uuids) == ["acme-run", "widgets-run"]
+
+    def test_plain_literal_path_with_no_pointer_lists_everything_matching(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme" / "customers" / "2025",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets" / "customers" / "2025",
+            "2026-01-02_00-00-00",
+            "widgets-run",
+            {},
+        )
+        other_run = _make_run(
+            tmp_path / "widgets" / "customers" / "2026",
+            "2026-01-03_00-00-00",
+            "other-run",
+            {},
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {"acme": [acme_run], "widgets": [widgets_run, other_run]},
+        )
+        results = _finder(
+            "$*.results.customers/2025", str(tmp_path)
+        ).query()
+        assert sorted(results.uuids) == ["acme-run", "widgets-run"]
+
+    def test_no_pointer_pool_with_content_accessor_and_multiple_runs_is_rejected(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {"invoices": "acme-invoices"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets",
+            "2026-01-02_00-00-00",
+            "widgets-run",
+            {"invoices": "widgets-invoices"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.results.:home().invoices:errors()", str(tmp_path)
+            ).query()
+
+    def test_no_pointer_with_a_field_accessor_is_poolable(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "acme-run", {}
+        )
+        _write_json(
+            Path(acme_run) / "manifest.json",
+            {"run_uuid": "acme-run", "named_paths_name": "acme"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets", "2026-01-02_00-00-00", "widgets-run", {}
+        )
+        _write_json(
+            Path(widgets_run) / "manifest.json",
+            {"run_uuid": "widgets-run", "named_paths_name": "widgets"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder(
+            "$*.results.:named_paths_name()", str(tmp_path)
+        ).resolve()
+        assert sorted((r.uuid, r.data) for r in results.results) == [
+            ("acme-run", "acme"),
+            ("widgets-run", "widgets"),
+        ]
 
 
 class TestPositionEnforcement:


### PR DESCRIPTION
## Summary
`ReferenceExpression3` -- `UNION`/`SUBTRACT`/`INTERSECT` over references, built on the two pieces from #251. Each side is a plain reference string or another `ReferenceExpression3` (sub-expressions). `resolve()` is the only entry point -- `INTERSECT`/`SUBTRACT`'s join key is resolved field-accessor data (`result.data`), not path/uuid, which mean different things per datatype and aren't comparable across them.

- `UNION` never looks at the join key at all -- pure concatenation of both sides' native results, deduplicated by `ReferenceResult3`'s own existing equality.
- `INTERSECT`/`SUBTRACT` reduce the **right** side to a plain set of resolved keys (which right-hand item carried a key never matters, right-hand items never appear in the output), then filter the **left** side -- deduplicated by full item equality only, never collapsed by key.

## A real bug, caught by testing rather than design review
An early draft collapsed the *left* side to one item per distinct key before filtering, same as the right side. That's correct for "one result per identity," but silently wrong for David's own worked "orders" example ("give me all the runs where the named-paths group had an orders statement") -- if group A has 2 runs and group B has 3, and both groups have "orders," the answer needs to be all 5 runs, not one exemplar per group. Fixed, and verified against the doc's own worked example exactly: 7/6/5 `UNION` variants and 5/2/0 `INTERSECT` variants, both reproduced. `references_notes/notes/reference_expressions_notes.txt` corrected to match (it had documented the wrong rule as "settled").

## Also surfaced, not fixed here
Neither `CsvpathsReferenceFinder3` nor `ResultsReferenceFinder3` support `root_major='*'` traversal combined with a trailing field accessor yet -- a pre-existing Finder limitation, not a `ReferenceExpression3` problem, but it blocks the most literal phrasing of "every group"/"every run" without already knowing the candidate names. Worked around in the tests via a sub-expression (`UNION` of two literal per-group queries) -- exactly what a caller can write today. Noted in the doc as worth prioritizing, since without it every expression needs already-known `root_major` names on both sides, which undercuts a lot of the point of reference expressions.

## Test plan
- [x] `tests/references/test_reference_expression_3.py` (new, 24 tests) -- pure operation-logic tests, constructor validation, and a full end-to-end "orders" scenario with real on-disk fixtures reproducing the doc's exact worked numbers
- [x] `tests/references/` -- 1061 passed
- [x] Full suite -- 2649 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)
