### PR TITLE
Allow a field accessor alongside '*' traversal in RESULTS/CSVPATHS

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -275,11 +275,16 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
           FILES.
 
         Deliberately narrow, matching FILES' own scoping: combining '*'
-        traversal with :manifest()/a field-accessor function, or
-        name_three, is not yet supported -- raises clearly rather than
-        guessing (this also avoids a real bug: those code paths call
-        get_manifest_for_name(reference.root_major), which would break
-        if root_major were the '*' token instead of a literal name).
+        traversal with :manifest(), name_three, is not yet supported --
+        raises clearly rather than guessing. A registered field-accessor
+        function (e.g. :uuid(), :named_paths_name()) IS now supported
+        alongside the pointer (added 2026-08-18, mirroring RESULTS' own
+        equivalent fix) -- _extract_data() resolves it via
+        _group_manifest_entry(), which searches every group's manifest
+        for the matched uuid when root_major is the '*' token, instead
+        of the direct get_manifest_for_name(reference.root_major) call
+        every non-star call site uses (that direct call is what broke
+        for '*' before this fix -- no group is actually named "*").
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -308,18 +313,17 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         built = ReferenceFunctionFactory.build_chain(calls)
         is_grouped = any(f.name == "all" for f in built)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
-        unsupported = (
-            any(f.name == "manifest" for f in built)
-            or any(f.name in ("from", "to") for f in built)
-            or self._find_field_function_call(calls) is not None
+        unsupported = any(f.name == "manifest" for f in built) or any(
+            f.name in ("from", "to") for f in built
         )
         if unsupported:
             raise ReferenceException3(
                 "CsvpathsReferenceFinder3 does not yet support combining "
-                "'*' traversal with :manifest(), ':from()'/':to()', or a "
-                "field-accessor function -- only a plain pointer "
-                "(:first()/:last()/:index(n)), optionally combined with "
-                ":all() for one result per group, is supported so far."
+                "'*' traversal with :manifest() or ':from()'/':to()' -- "
+                "only a plain pointer (:first()/:last()/:index(n)), "
+                "optionally combined with :all() for one result per "
+                "group, or a registered field-accessor function (e.g. "
+                ":uuid()), is supported so far."
             )
 
         if is_grouped:
@@ -398,11 +402,18 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 # :manifest() riding alongside the real version-selecting
                 # pointer already in name_one's own combined chain (e.g.
                 # ":last():manifest()") -- give the matched version's own
-                # manifest entry, not the whole raw file.
-                manifest = self.csvpaths.paths_manager.get_manifest_for_name(
-                    reference.root_major
+                # manifest entry, not the whole raw file. root_major is
+                # never the '*' token here -- Rule 1b above already
+                # claims the star + bare-pointer-plus-manifest shape, and
+                # _query_star_traversal itself still rejects ':manifest()'
+                # combined with '*' traversal -- but routed through
+                # _group_manifest_entry() anyway for consistency with the
+                # field-accessor branch below, which genuinely does need
+                # to handle root_major being '*'.
+                _, entry = self._group_manifest_entry(
+                    reference.root_major, result.uuid
                 )
-                return self._find_manifest_entry_by_uuid(manifest, result.uuid)
+                return entry
         if kind == Reference3.METADATA_FIELD:
             # a registered field-accessor function (e.g. :uuid()) in the
             # same combined chain :manifest() itself rides in -- extracts
@@ -416,15 +427,22 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 )
                 key_path = function_cls.KEY.get(reference.datatype)
                 if function_cls.SOURCE == "definition":
+                    # a definition.json-backed field (e.g. :scripts(),
+                    # :webhooks()) is keyed by group NAME, not uuid --
+                    # _group_manifest_entry() re-derives which real group
+                    # this is even when root_major is the '*' token
+                    # (added 2026-08-18, see that method's own docstring).
+                    group_name, _ = self._group_manifest_entry(
+                        reference.root_major, result.uuid
+                    )
                     config = self.csvpaths.paths_manager.describer.get_config(
-                        reference.root_major
+                        group_name
                     )
                     entry = config.model_dump(exclude_none=True)
                 else:
-                    manifest = self.csvpaths.paths_manager.get_manifest_for_name(
-                        reference.root_major
+                    _, entry = self._group_manifest_entry(
+                        reference.root_major, result.uuid
                     )
-                    entry = self._find_manifest_entry_by_uuid(manifest, result.uuid)
                 return self._extract_field_value(entry, key_path)
         if kind != Reference3.FIRST_PARTY:
             raise ReferenceException3(
@@ -466,6 +484,30 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             return None
         statements = selected.get("named_paths") or []
         return statements[index]
+
+    def _group_manifest_entry(self, root_major, uuid: str) -> tuple:
+        """returns (group_name, manifest_entry) for the version matching
+        uuid. When root_major is the '*' token (a '*' traversal result --
+        added 2026-08-18) the matched version could belong to any named-
+        paths group, so every group's own manifest is searched for the
+        matching uuid -- uuids are assumed globally unique, the same
+        assumption _find_manifest_entry_by_uuid's every other call site
+        already makes. Otherwise root_major is a literal group name --
+        looked up directly, same as every call site used to do inline
+        before this helper existed. Acceptable performance-wise since a
+        csvpaths install typically has few named-paths groups, unlike
+        RESULTS' potentially-large run history (RESULTS did not need an
+        equivalent helper for this same reason -- see
+        ResultsReferenceFinder3._extract_data's own comment on why)."""
+        if isinstance(root_major, Star3):
+            for name in self.csvpaths.paths_manager.named_paths_names:
+                manifest = self.csvpaths.paths_manager.get_manifest_for_name(name)
+                entry = self._find_manifest_entry_by_uuid(manifest, uuid)
+                if entry is not None:
+                    return name, entry
+            return None, None
+        manifest = self.csvpaths.paths_manager.get_manifest_for_name(root_major)
+        return root_major, self._find_manifest_entry_by_uuid(manifest, uuid)
 
     def _resolve_versions(self, name_one, manifest: list) -> list:
         """name_one's sole job for csvpaths is selecting which

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -519,16 +519,18 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
         """root_major == "*" -- query across every named-results group,
-        not just one. Deliberately the narrowest '*' traversal of the
-        three datatypes: only a bare pointer (:first()/:last()/
-        :index(n)), no literal/'*' path narrowing, no name_three, no
-        ':all()', no :manifest()/a field-accessor function. A bare
-        pointer here means the same zero-level-only ("direct children
-        of each run's own group's home") restriction the literal-root
-        query() case now applies -- settled 2026-08-10, see that
-        method's own comments and :flatten() for the any-depth case.
-        Two things make the wider cases genuinely harder here, not just
-        unbuilt yet (unlike files/csvpaths, where the same shapes were
+        not just one. Deliberately narrow: only a bare pointer
+        (:first()/:last()/:index(n)), optionally combined with a run-
+        level field-accessor function (e.g. :uuid(), :named_paths_name()
+        -- added 2026-08-18, see this method's own field_call comment
+        below) -- still no literal/'*' path narrowing, no name_three, no
+        ':all()', no :manifest(). A bare pointer here means the same
+        zero-level-only ("direct children of each run's own group's
+        home") restriction the literal-root query() case now applies --
+        settled 2026-08-10, see that method's own comments and
+        :flatten() for the any-depth case. Two things make the
+        remaining wider cases genuinely harder here, not just unbuilt
+        yet (unlike files/csvpaths, where the same shapes were
         straightforward generalizations):
 
         - RESULTS' own ':all()' already means something different --
@@ -600,13 +602,36 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # but rejecting it explicitly, like everything else that is not
         # a pointer, still avoids silently applying that filter to what
         # should be an any-depth query.
-        non_pointers = [f for f in built if f.ROLE != Function3.POINTER]
+        # added 2026-08-18 -- a run-level field accessor (e.g. :uuid(),
+        # :named_paths_name()) is now allowed alongside the pointer:
+        # _results_for_run() (below) already builds each candidate's
+        # ReferenceResult3 from its own real run directory, independent
+        # of any group-name context, so resolving a field from it needs
+        # nothing star-traversal-specific -- see _extract_data()'s own
+        # comment on why this "just works" once let through. Previously
+        # rejected here alongside :all()/:flatten()/:groups()/:manifest()/
+        # ':from()'/':to()', which is still narrower than that reasoning
+        # required -- David: this gap "invalidates a high-value class of
+        # scenarios" for reference expressions, which need exactly this
+        # (a scalar per matched candidate, searched across every group)
+        # to compare RESULTS against CSVPATHS/FILES at all.
+        # _find_field_function_call(built), not calls -- calls holds raw
+        # FunctionCall3 parse shapes, built holds the real constructed
+        # Function3 instances non_pointers iterates below; comparing a
+        # raw-list match against a built-list entry via "is" would never
+        # succeed, since they are different objects even for "the same"
+        # function.
+        field_call = self._find_field_function_call(built)
+        non_pointers = [
+            f for f in built if f.ROLE != Function3.POINTER and f is not field_call
+        ]
         if non_pointers:
             raise ReferenceException3(
                 f"ResultsReferenceFinder3 does not yet support "
                 f":{non_pointers[0].name}() combined with '*' traversal -- "
-                "only a bare pointer (:first()/:last()/:index(n)) is "
-                "supported so far."
+                "only a bare pointer (:first()/:last()/:index(n)), "
+                "optionally combined with a run-level field-accessor "
+                "function (e.g. :uuid()), is supported so far."
             )
         pointer = self._pointer_from_calls(calls)
         if pointer is None:
@@ -649,7 +674,28 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
     def _extract_data(self, result: ReferenceResult3):
         reference = self.ref.parsed
-        if isinstance(reference.root_major, Star3):
+        name_one_calls = self._combined_name_one_calls(reference.name_one)
+        has_manifest = any(
+            seg.contains_function_named("manifest")
+            for seg in name_one_calls
+            if isinstance(seg, FunctionCall3)
+        )
+        if isinstance(reference.root_major, Star3) and has_manifest:
+            # Rule 1a/1b -- the bare/pointer-plus-":manifest()" global-
+            # ledger shapes, both handled entirely by query()'s own
+            # earlier branches (see that method) -- narrowed 2026-08-18
+            # to require has_manifest specifically, not just root_major
+            # being '*': previously this branch fired for ANY star-
+            # rooted reference unconditionally, which (a) was never
+            # actually exercised by a real test for the plain-bare-
+            # pointer-no-manifest case, and (b) would have silently
+            # given the wrong answer there (the global ledger entry,
+            # not the run's own content) once _query_star_traversal
+            # started supporting a plain field accessor too. A star-
+            # traversal result with neither :manifest() nor a field
+            # accessor now correctly falls through to the same "no
+            # single unambiguous payload" rule the literal-root case
+            # already uses at the bottom of this method.
             if result.uuid is not None:
                 # Rule 1b -- a pointer already reduced the global ledger
                 # to one entry in query(); re-derive it by run_uuid
@@ -666,12 +712,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # has_manifest branch below does that join, but only
             # because it deals with a run directory, not a file).
             return self._read_well_known_json(result.path)
-        name_one_calls = self._combined_name_one_calls(reference.name_one)
-        has_manifest = any(
-            seg.contains_function_named("manifest")
-            for seg in name_one_calls
-            if isinstance(seg, FunctionCall3)
-        )
         if has_manifest:
             # :manifest() rides beside the run-selecting pointer in
             # name_one (e.g. "$acme.results.customers/2025:first()
@@ -712,6 +752,15 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             # "no name_three" restriction as :manifest(), for the same
             # reason: asking for both a run-level field and a specific
             # instance at once is not a supported combination.
+            #
+            # also correctly serves root_major='*' now (added
+            # 2026-08-18, once _query_star_traversal started allowing a
+            # field accessor through) with no extra logic needed here --
+            # result.path is already the matched run's own real
+            # directory regardless of which group it came from (see
+            # _results_for_run), so reading its own manifest.json needs
+            # no group-name context at all, unlike CSVPATHS' equivalent
+            # fix, which does.
             if reference.name_three is not None:
                 raise ReferenceException3(
                     "ResultsReferenceFinder3 does not support combining "

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -1,6 +1,7 @@
 import pytest
 
 from csvpath.references.csvpaths_reference_finder_3 import CsvpathsReferenceFinder3
+from csvpath.references.reference_3 import Star3
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 from csvpath.references.reference_results_3 import ReferenceResult3
@@ -37,12 +38,15 @@ GROUP_HOME = "named_paths/acme"
 
 
 class _FakePathsDescriber:
-    def __init__(self, definition: dict):
+    def __init__(self, definition: dict, definitions_by_name: dict | None = None):
         self._definition = definition
+        self._definitions_by_name = definitions_by_name
 
     def get_config(self, name):
         from csvpath.managers.paths.paths_descriptor import GroupConfig
 
+        if self._definitions_by_name is not None:
+            return GroupConfig(**self._definitions_by_name[name])
         return GroupConfig(**self._definition)
 
 
@@ -54,6 +58,7 @@ class _FakePathsManager:
         definition: dict | None = None,
         ledger=None,
         by_name: dict | None = None,
+        definitions_by_name: dict | None = None,
     ):
         self._manifest = manifest
         self._home = home
@@ -63,6 +68,11 @@ class _FakePathsManager:
         # which need more than one distinct named-paths group. Every
         # other test uses the single manifest above.
         self._by_name = by_name
+        # definitions_by_name: {name: definition} -- only used by '*'
+        # traversal tests for definition.json-backed fields (:scripts()
+        # etc), to prove the CORRECT group's own definition is read, not
+        # just any -- added 2026-08-18 alongside _group_manifest_entry().
+        self._definitions_by_name = definitions_by_name
 
     def get_manifest_for_name(self, name):
         if self._by_name is not None:
@@ -84,7 +94,7 @@ class _FakePathsManager:
 
     @property
     def describer(self):
-        return _FakePathsDescriber(self._definition)
+        return _FakePathsDescriber(self._definition, self._definitions_by_name)
 
 
 class _FakeConfig:
@@ -105,9 +115,16 @@ def _finder(
     inputs_csvpaths_path: str | None = None,
     ledger: list | None = None,
     by_name: dict | None = None,
+    definitions_by_name: dict | None = None,
 ) -> CsvpathsReferenceFinder3:
     csvpaths = _FakeCsvPaths(
-        _FakePathsManager(manifest, definition=definition, ledger=ledger, by_name=by_name),
+        _FakePathsManager(
+            manifest,
+            definition=definition,
+            ledger=ledger,
+            by_name=by_name,
+            definitions_by_name=definitions_by_name,
+        ),
         inputs_csvpaths_path=inputs_csvpaths_path,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
@@ -615,6 +632,156 @@ class TestStarTraversalFlatten:
     def test_name_three_combined_with_traversal_is_not_yet_supported(self):
         with pytest.raises(ReferenceException3):
             _star_finder("$*.csvpaths.:last().0").query()
+
+
+class TestStarTraversalFieldAccessor:
+    # closes the gap ReferenceExpression3 needed -- a registered field-
+    # accessor function can now ride alongside the pointer in '*'
+    # traversal (added 2026-08-18), resolving from whichever real group
+    # matched via _group_manifest_entry(), which re-derives the matched
+    # group's own name/manifest from the uuid the pointer already
+    # selected -- unlike RESULTS, CSVPATHS genuinely needs this, since
+    # get_manifest_for_name(reference.root_major) breaks when
+    # root_major is the '*' token (no group is actually named "*").
+    def test_flatten_shape_with_a_field_accessor_now_works(self):
+        by_name = {
+            "alpha": [
+                {
+                    "group_file_path": "named_paths/alpha/group.csvpath",
+                    "uuid": "a-v1",
+                    "time": "2026-01-01T00:00:00+00:00",
+                    "named_paths_name": "alpha",
+                }
+            ],
+            "beta": [
+                {
+                    "group_file_path": "named_paths/beta/group.csvpath",
+                    "uuid": "b-v1",
+                    "time": "2026-01-03T00:00:00+00:00",
+                    "named_paths_name": "beta",
+                }
+            ],
+        }
+        results = _finder(
+            "$*.csvpaths.:last():named_paths_name()", by_name=by_name
+        ).resolve()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "b-v1"
+        assert results.results[0].data == "beta"
+
+    def test_grouped_shape_with_a_field_accessor_now_works(self):
+        by_name = {
+            "alpha": [
+                {
+                    "group_file_path": "named_paths/alpha/group.csvpath",
+                    "uuid": "a-v1",
+                    "time": "2026-01-01T00:00:00+00:00",
+                    "named_paths_name": "alpha",
+                },
+                {
+                    "group_file_path": "named_paths/alpha/group.csvpath",
+                    "uuid": "a-v2",
+                    "time": "2026-01-02T00:00:00+00:00",
+                    "named_paths_name": "alpha",
+                },
+            ],
+            "beta": [
+                {
+                    "group_file_path": "named_paths/beta/group.csvpath",
+                    "uuid": "b-v1",
+                    "time": "2026-01-03T00:00:00+00:00",
+                    "named_paths_name": "beta",
+                }
+            ],
+        }
+        results = _finder(
+            "$*.csvpaths.:all():last():named_paths_name()", by_name=by_name
+        ).resolve()
+        assert len(results.results) == 2
+        assert {r.data for r in results.results} == {"alpha", "beta"}
+        assert {r.uuid for r in results.results} == {"a-v2", "b-v1"}
+
+    def test_field_accessor_exemption_does_not_let_manifest_through_too(self):
+        # a field accessor is now exempt from the unsupported check, but
+        # a genuinely unsupported extra (:manifest()) riding alongside
+        # it is still rejected -- the exemption is narrow, not "anything
+        # goes once one field accessor is present". A third function
+        # also pushes this reference past _pointer_before_manifest's own
+        # exactly-two-functions Rule 1b shape, so it genuinely reaches
+        # _query_star_traversal's guard rather than being intercepted
+        # earlier.
+        with pytest.raises(ReferenceException3):
+            _star_finder("$*.csvpaths.:last():named_paths_name():manifest()").query()
+
+    def test_definition_sourced_field_reads_the_matched_groups_own_config(self):
+        # :scripts() (SOURCE == "definition") is the other branch
+        # _group_manifest_entry() serves -- it needs the matched GROUP
+        # NAME, not just its manifest entry, to call describer.get_
+        # config(name). Proves the correct group's own definition.json
+        # is read, not alpha's by accident, by giving each group a
+        # different "scripts" config and asserting on beta's value.
+        by_name = {
+            "alpha": [
+                {
+                    "group_file_path": "named_paths/alpha/group.csvpath",
+                    "uuid": "a-v1",
+                    "time": "2026-01-01T00:00:00+00:00",
+                }
+            ],
+            "beta": [
+                {
+                    "group_file_path": "named_paths/beta/group.csvpath",
+                    "uuid": "b-v1",
+                    "time": "2026-01-03T00:00:00+00:00",
+                }
+            ],
+        }
+        definitions_by_name = {
+            "alpha": {"scripts": {"on_complete_all": "alpha_notify.py"}},
+            "beta": {"scripts": {"on_complete_all": "beta_notify.py"}},
+        }
+        results = _finder(
+            "$*.csvpaths.:last():scripts()",
+            by_name=by_name,
+            definitions_by_name=definitions_by_name,
+        ).resolve()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "b-v1"
+        assert results.results[0].data == {"on_complete_all": "beta_notify.py"}
+
+
+class TestGroupManifestEntry:
+    # _group_manifest_entry() -- added 2026-08-18 alongside the field-
+    # accessor exemption above, so both the METADATA_FIELD manifest-
+    # sourced branch and the :scripts()/:webhooks()/:transfers()/
+    # :destinations() definition-sourced branch can re-derive which real
+    # group a star-traversal result came from, tested directly here
+    # rather than only indirectly through resolve().
+    def test_star_root_major_finds_the_correct_group(self):
+        by_name = {
+            "alpha": [{"group_file_path": "x", "uuid": "a-v1"}],
+            "beta": [{"group_file_path": "y", "uuid": "b-v1"}],
+        }
+        finder = _finder("$*.csvpaths.:last()", by_name=by_name)
+        name, entry = finder._group_manifest_entry(Star3(), "b-v1")
+        assert name == "beta"
+        assert entry["uuid"] == "b-v1"
+
+    def test_star_root_major_with_unknown_uuid_gives_none_none(self):
+        by_name = {"alpha": [{"group_file_path": "x", "uuid": "a-v1"}]}
+        finder = _finder("$*.csvpaths.:last()", by_name=by_name)
+        name, entry = finder._group_manifest_entry(Star3(), "missing-uuid")
+        assert name is None
+        assert entry is None
+
+    def test_literal_root_major_looks_up_directly_no_group_search(self):
+        # a literal root_major never needs to search every group -- this
+        # mirrors what every non-star call site did inline before this
+        # helper existed.
+        finder = _finder("$acme.csvpaths.:last()")
+        name, entry = finder._group_manifest_entry("acme", "v1-uuid")
+        assert name == "acme"
+        assert entry["uuid"] == "v1-uuid"
 
 
 class TestStarTraversalGroup:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1791,6 +1791,65 @@ class TestStarTraversal:
         with pytest.raises(ReferenceException3):
             _finder("$*.results.:last().0", two_group_archive).query()
 
+    def test_field_accessor_combined_with_star_traversal_now_works(self, tmp_path):
+        # closes the gap ReferenceExpression3 needed -- a run-level
+        # field accessor can now ride alongside the pointer in '*'
+        # traversal, resolving from whichever real run matched,
+        # regardless of which group it came from (see _extract_data's
+        # own comment on why no group-name context is needed for
+        # RESULTS, unlike CSVPATHS' equivalent fix).
+        acme_base = tmp_path / "acme"
+        acme_run1 = _make_run(acme_base, "2026-01-01_00-00-00", "acme-run1-uuid", {})
+        _write_json(
+            Path(acme_run1) / "manifest.json",
+            {"run_uuid": "acme-run1-uuid", "named_paths_name": "acme"},
+        )
+        widgets_base = tmp_path / "widgets"
+        widgets_run1 = _make_run(
+            widgets_base, "2026-01-03_00-00-00", "widgets-run1-uuid", {}
+        )
+        _write_json(
+            Path(widgets_run1) / "manifest.json",
+            {"run_uuid": "widgets-run1-uuid", "named_paths_name": "widgets"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {"widgets": [widgets_run1], "acme": [acme_run1]},
+        )
+        results = _finder(
+            "$*.results.:last():named_paths_name()", str(tmp_path)
+        ).resolve()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "widgets-run1-uuid"
+        assert results.results[0].data == "widgets"
+
+    def test_field_accessor_exemption_does_not_let_a_second_extra_through(
+        self, two_group_archive
+    ):
+        # a field accessor is now exempt from the non-pointer rejection,
+        # but a genuinely unsupported extra (e.g. :groups()) riding
+        # alongside it is still rejected -- proves the exemption is
+        # narrowly scoped to the one matched field call, not "anything
+        # goes once one field accessor is present".
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.results.:last():named_paths_name():groups()",
+                two_group_archive,
+            ).query()
+
+    def test_bare_pointer_resolve_with_no_manifest_and_no_field_accessor_gives_none(
+        self, two_group_archive
+    ):
+        # previously-latent bug: _extract_data's star-traversal branch
+        # checked isinstance(root_major, Star3) unconditionally, so a
+        # plain resolve() with no :manifest() and no field accessor
+        # incorrectly took the global-ledger-by-uuid path (Rule 1b)
+        # instead of falling through to "no single unambiguous payload"
+        # -- confirmed via grep that no existing test called resolve()
+        # on a bare star-traversal reference before this fix.
+        result = _finder("$*.results.:last()", two_group_archive).resolve()
+        assert result.results[0].data is None
+
 
 class TestPositionEnforcement:
     # ReferenceFinder3._check_position() -- added 2026-08-14, the


### PR DESCRIPTION
## Summary
Closes the gap flagged while building `ReferenceExpression3` (#252): neither `ResultsReferenceFinder3` nor `CsvpathsReferenceFinder3` let a run/version-level field-accessor function (e.g. `:uuid()`, `:named_paths_name()`) ride alongside the pointer when `root_major` is the `'*'` token. Both raised clearly, but this blocked the most natural phrasing of "every group"/"every run" without already knowing candidate names -- exactly what reference expressions need to compare RESULTS against CSVPATHS/FILES.

- **RESULTS**: `_query_star_traversal`'s guard now exempts one matched field call. `_extract_data`'s field-accessor branch already read from the matched run's own real directory, independent of which group it came from, so it "just worked" once let through.
- **CSVPATHS**: genuinely needed more -- field-accessor resolution reads a matched version's own manifest entry via `get_manifest_for_name(root_major)`, which breaks when `root_major` is `'*'` (no group is literally named "*"). Added `_group_manifest_entry(root_major, uuid)`, which searches every named-paths group's manifest for the matching uuid when `root_major` is `'*'` (uuids assumed globally unique, same assumption already made elsewhere), returning `(group_name, entry)`. Used for both manifest-sourced fields and definition.json-backed ones (`:scripts()`/`:webhooks()`/`:transfers()`/`:destinations()`), which need the group name to call `describer.get_config(name)`.

## A separate, previously-latent bug found and fixed along the way
`_extract_data`'s star-traversal branch in RESULTS checked `isinstance(root_major, Star3)` unconditionally, so ANY star-rooted `resolve()` -- even a bare pointer with no `:manifest()` -- incorrectly took the global-ledger-by-uuid lookup path instead of falling through to "no single unambiguous payload -> None". Confirmed via grep that no existing test ever called `.resolve()` (as opposed to `.query()`) on a bare star-traversal reference before this. Fixed by requiring `has_manifest` as part of that branch's condition.

## Test plan
- [x] `tests/references/test_results_reference_finder_3.py` -- 3 new tests (field accessor combined with traversal, the exemption not over-widening to a second unsupported extra, the latent bare-pointer `resolve()` bug)
- [x] `tests/references/test_csvpaths_reference_finder_3.py` -- 4 new tests (flatten- and grouped-shape field accessors, the exemption not over-widening, the definition-sourced branch reading the correct group's own config) plus 3 direct unit tests for `_group_manifest_entry` itself
- [x] `tests/references/` -- 1047 passed
- [x] Full suite -- 2635 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)

## Not in this PR
`tests/references/test_reference_expression_3.py` (from the still-open, separate PR #252) has a `TestStarTraversalPlusFieldAccessorIsNotYetSupported` class asserting this exact gap raises -- that file lives on a different branch (`feature/references-v3-reference-expression`), not this one, so updating it (and re-testing `ReferenceExpression3`'s "orders" example against real `'*'` traversal now that it works) is follow-up work for whenever #252 is revisited, not part of this change.
