### PR TITLE
Support :having()/:flatten()/:all()/path-narrowing/name_three combined with '*' traversal

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -285,6 +285,22 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         of the direct get_manifest_for_name(reference.root_major) call
         every non-star call site uses (that direct call is what broke
         for '*' before this fix -- no group is actually named "*").
+
+        ':having("identity")' is ALSO now supported (added 2026-08-18,
+        alongside RESULTS' own ':flatten()' fix) -- filters each group's
+        own manifest down to versions whose "named_paths_identities"
+        actually contains that identity, BEFORE either mode's own
+        pointer/grouping reduction, same position it occupies in
+        _resolve_versions()'s single-group precedent. This closes a
+        real, previously-latent bug, not just a missing feature:
+        ':having()' was never checked for at all here before this fix --
+        neither rejected as unsupported NOR applied -- so it was
+        silently DROPPED, e.g. "$*.csvpaths.:all():having('orders')"
+        returned every group's every version, unfiltered, confirmed live
+        before this fix. David's own "orders" worked example
+        (references_notes/notes/reference_expressions_notes.txt) needs
+        exactly this ("every group with an 'orders' statement") as its
+        right-hand side.
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -312,6 +328,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         calls = [name_one.path[0], *name_one.functions]
         built = ReferenceFunctionFactory.build_chain(calls)
         is_grouped = any(f.name == "all" for f in built)
+        having_call = next((f for f in built if f.name == "having"), None)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         unsupported = any(f.name == "manifest" for f in built) or any(
             f.name in ("from", "to") for f in built
@@ -321,15 +338,26 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 "CsvpathsReferenceFinder3 does not yet support combining "
                 "'*' traversal with :manifest() or ':from()'/':to()' -- "
                 "only a plain pointer (:first()/:last()/:index(n)), "
-                "optionally combined with :all() for one result per "
-                "group, or a registered field-accessor function (e.g. "
-                ":uuid()), is supported so far."
+                "optionally combined with :all(), :having(\"identity\"), "
+                "or a registered field-accessor function (e.g. :uuid()), "
+                "is supported so far."
             )
+
+        def _having_filtered(manifest: list) -> list:
+            if having_call is None:
+                return manifest
+            return [
+                entry
+                for entry in manifest
+                if having_call.arg in (entry.get("named_paths_identities") or [])
+            ]
 
         if is_grouped:
             selected_versions = []
             for name in self.csvpaths.paths_manager.named_paths_names:
-                manifest = self.csvpaths.paths_manager.get_manifest_for_name(name)
+                manifest = _having_filtered(
+                    self.csvpaths.paths_manager.get_manifest_for_name(name)
+                )
                 if pointers:
                     selected = self._apply_pointer(pointers[0], manifest)
                     if selected is not None:
@@ -347,7 +375,9 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             pooled = []
             for name in self.csvpaths.paths_manager.named_paths_names:
                 pooled.extend(
-                    self.csvpaths.paths_manager.get_manifest_for_name(name)
+                    _having_filtered(
+                        self.csvpaths.paths_manager.get_manifest_for_name(name)
+                    )
                 )
             pooled.sort(key=lambda e: e["time"])
             selected = self._apply_pointer(pointers[0], pooled)

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -26,10 +26,12 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    two exceptions carved out before general traversal (Rule 1a/1b, a
 #    bare/ordinal-indexed :manifest() reads the global archive ledger); any
 #    other use of "*" goes through _query_star_traversal(), which is
-#    deliberately the narrowest of the three datatypes' traversals (bare
-#    pointer only, no path narrowing/:all()/name_three/:manifest()/field
-#    accessors) -- see that method's own docstring for why the wider cases
-#    are genuinely harder here, not just unbuilt yet.
+#    deliberately the narrowest of the three datatypes' traversals -- a bare
+#    pointer, optionally combined with ':flatten()' and/or a run-level field-
+#    accessor function (both added 2026-08-18), but still no path narrowing/
+#    :all()/name_three/:manifest() -- see that method's own docstring for
+#    why the remaining wider cases are genuinely harder here, not just
+#    unbuilt yet.
 #  - name_one has TWO legal shapes, matching the spec's own examples
 #    ("$acme.results.:all()"/"$acme.results.:last()" alongside
 #    "$acme.results.customers/2025:first()"):
@@ -523,15 +525,17 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         (:first()/:last()/:index(n)), optionally combined with a run-
         level field-accessor function (e.g. :uuid(), :named_paths_name()
         -- added 2026-08-18, see this method's own field_call comment
-        below) -- still no literal/'*' path narrowing, no name_three, no
-        ':all()', no :manifest(). A bare pointer here means the same
-        zero-level-only ("direct children of each run's own group's
-        home") restriction the literal-root query() case now applies --
-        settled 2026-08-10, see that method's own comments and
-        :flatten() for the any-depth case. Two things make the
-        remaining wider cases genuinely harder here, not just unbuilt
-        yet (unlike files/csvpaths, where the same shapes were
-        straightforward generalizations):
+        below) and/or ':flatten()' (any-depth pooling across every
+        group -- added 2026-08-18, see this method's own flatten_call
+        comment below) -- still no literal/'*' path narrowing, no
+        name_three, no ':all()', no :manifest(). A bare pointer with no
+        ':flatten()' here means the same zero-level-only ("direct
+        children of each run's own group's home") restriction the
+        literal-root query() case now applies -- settled 2026-08-10, see
+        that method's own comments. Two things make the remaining wider
+        cases genuinely harder here, not just unbuilt yet (unlike
+        files/csvpaths, where the same shapes were straightforward
+        generalizations):
 
         - RESULTS' own ':all()' already means something different --
           pooling every csvpath-statement instance WITHIN one already-
@@ -597,11 +601,6 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # actually caught everything it should have -- ':groups()' and
         # ':from()' both silently swallowed instead of raising, the
         # same bug class already fixed for the literal-root case above.
-        # ':flatten()' would have been a no-op here anyway (traversal
-        # already pools every discovered run at the same zero level),
-        # but rejecting it explicitly, like everything else that is not
-        # a pointer, still avoids silently applying that filter to what
-        # should be an any-depth query.
         # added 2026-08-18 -- a run-level field accessor (e.g. :uuid(),
         # :named_paths_name()) is now allowed alongside the pointer:
         # _results_for_run() (below) already builds each candidate's
@@ -622,16 +621,40 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # succeed, since they are different objects even for "the same"
         # function.
         field_call = self._find_field_function_call(built)
+        # added 2026-08-18 -- ':flatten()' (any-depth pooling, mirroring
+        # its own literal-root meaning -- see is_flattened in query()
+        # above) is now also allowed alongside the pointer, for the same
+        # reason a field accessor is: David's own "orders" worked
+        # example (references_notes/notes/reference_expressions_notes.
+        # txt) needs "every run, any depth, across every group" as its
+        # left-hand side, which a zero-level-only bare pointer cannot
+        # express. build_chain() above already validated ':flatten()'
+        # takes no argument (Function3.check_valid()'s generic ARG_TYPES
+        # check, called from build()) -- no separate check needed here.
+        # ':all()'/':groups()' stay unsupported -- RESULTS' own ':all()'
+        # already means something else entirely at star-traversal's
+        # position (see this method's own docstring), and ':groups()'
+        # (any-depth GROUP, one result per distinct value observed) has
+        # no established per-GROUP-of-named-results-groups meaning the
+        # way ':flatten()' (any-depth POOL) does -- left for if/when a
+        # real use case asks for it, same as the literal-root case's own
+        # deferred ':groups()' precedent.
+        flatten_call = next((f for f in built if f.name == "flatten"), None)
         non_pointers = [
-            f for f in built if f.ROLE != Function3.POINTER and f is not field_call
+            f
+            for f in built
+            if f.ROLE != Function3.POINTER
+            and f is not field_call
+            and f is not flatten_call
         ]
         if non_pointers:
             raise ReferenceException3(
                 f"ResultsReferenceFinder3 does not yet support "
                 f":{non_pointers[0].name}() combined with '*' traversal -- "
                 "only a bare pointer (:first()/:last()/:index(n)), "
-                "optionally combined with a run-level field-accessor "
-                "function (e.g. :uuid()), is supported so far."
+                "optionally combined with ':flatten()' and/or a run-level "
+                "field-accessor function (e.g. :uuid()), is supported so "
+                "far."
             )
         pointer = self._pointer_from_calls(calls)
         if pointer is None:
@@ -641,19 +664,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "group with '*'."
             )
 
-        # zero-level (direct children of each run's own group's home)
-        # only -- same restriction the literal-root query() case now
-        # applies to a plain bare pointer, settled 2026-08-10. Each
-        # candidate's own group name (kept by _discover_run_homes since
-        # this is the traversal case) is needed to compute the right
-        # "home" per candidate -- different groups have different homes.
-        run_homes = [
-            rh
-            for rh, group in self._discover_run_homes(None)
-            if self._matches_prefix(
-                rh, self.csvpaths.results_manager.get_named_results_home(group), []
-            )
-        ]
+        if flatten_call is not None:
+            # any depth, every group -- _discover_run_homes(None) already
+            # discovers across every group with no depth restriction of
+            # its own (the zero-level restriction below is applied AFTER
+            # discovery, by the _matches_prefix filter, not by discovery
+            # itself), so no separate any-depth gathering logic is
+            # needed here.
+            run_homes = [rh for rh, _ in self._discover_run_homes(None)]
+        else:
+            # zero-level (direct children of each run's own group's
+            # home) only -- same restriction the literal-root query()
+            # case now applies to a plain bare pointer, settled
+            # 2026-08-10. Each candidate's own group name (kept by
+            # _discover_run_homes since this is the traversal case) is
+            # needed to compute the right "home" per candidate --
+            # different groups have different homes.
+            run_homes = [
+                rh
+                for rh, group in self._discover_run_homes(None)
+                if self._matches_prefix(
+                    rh, self.csvpaths.results_manager.get_named_results_home(group), []
+                )
+            ]
         run_homes = sorted(run_homes, key=self._run_dir_sort_key)
         selected = self._apply_pointer(pointer, run_homes)
         if selected is None:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -27,11 +27,17 @@ from .reference_results_3 import ReferenceResult3, ReferenceResults3
 #    bare/ordinal-indexed :manifest() reads the global archive ledger); any
 #    other use of "*" goes through _query_star_traversal(), which is
 #    deliberately the narrowest of the three datatypes' traversals -- a bare
-#    pointer, optionally combined with ':flatten()' and/or a run-level field-
-#    accessor function (both added 2026-08-18), but still no path narrowing/
-#    :all()/name_three/:manifest() -- see that method's own docstring for
-#    why the remaining wider cases are genuinely harder here, not just
-#    unbuilt yet.
+#    pointer, optionally combined with ':flatten()', ':all()' (added
+#    2026-08-18/2026-08-19), and/or a run-level field-accessor function, but
+#    still no path narrowing/name_three/:manifest() -- see that method's own
+#    docstring for why the remaining wider cases are genuinely harder here,
+#    not just unbuilt yet. ':all()' here partitions by the COMPOSITE (named-
+#    results group, 1-level template value) key, resolving a real meaning-
+#    collision -- see "THE ':all()' MEANING COLLISION AT STAR TRAVERSAL" in
+#    references_notes/notes/normative_reference_examples.txt for the worked
+#    example that settled it, and FilesReferenceFinder3's own equivalent
+#    ':all()' precedent (its "file_home" key already IS a composite key,
+#    the named-file's name embedded as a path prefix).
 #  - name_one has TWO legal shapes, matching the spec's own examples
 #    ("$acme.results.:all()"/"$acme.results.:last()" alongside
 #    "$acme.results.customers/2025:first()"):
@@ -525,36 +531,33 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         (:first()/:last()/:index(n)), optionally combined with a run-
         level field-accessor function (e.g. :uuid(), :named_paths_name()
         -- added 2026-08-18, see this method's own field_call comment
-        below) and/or ':flatten()' (any-depth pooling across every
-        group -- added 2026-08-18, see this method's own flatten_call
+        below), ':flatten()' (any-depth pooling across every group --
+        added 2026-08-18, see this method's own flatten_call comment
+        below), or ':all()' (exactly-one-level GROUPING across every
+        group -- added 2026-08-19, see this method's own all_call
         comment below) -- still no literal/'*' path narrowing, no
-        name_three, no ':all()', no :manifest(). A bare pointer with no
-        ':flatten()' here means the same zero-level-only ("direct
-        children of each run's own group's home") restriction the
-        literal-root query() case now applies -- settled 2026-08-10, see
-        that method's own comments. Two things make the remaining wider
+        name_three, no :manifest(). A bare pointer with no ':flatten()'/
+        ':all()' here means the same zero-level-only ("direct children
+        of each run's own group's home") restriction the literal-root
+        query() case now applies -- settled 2026-08-10, see that
+        method's own comments. Two things make the remaining wider
         cases genuinely harder here, not just unbuilt yet (unlike
         files/csvpaths, where the same shapes were straightforward
         generalizations):
 
-        - RESULTS' own ':all()' already means something different --
-          pooling every csvpath-statement instance WITHIN one already-
-          selected run, at name_three (see _name_three_selector) -- so
-          there is no existing syntactic home for a "group by named-
-          results-group" trigger the way files/csvpaths both have via
-          a bare ':all()' in name_one. (Grouping by observed template
-          value WITHIN one already-literal group, David's three-
-          templates example, is a different, narrower thing and is
-          handled in the literal-root query() case, not here.)
         - Literal/'*' path narrowing (_matches_prefix) needs a
           candidate's own group's home directory to compute a relative
           match -- a bare run_home string, once pooled from
           _discover_run_homes(), no longer carries which group it came
           from on its own. _discover_run_homes() now keeps each pair's
-          group name specifically so the zero-level check above can
-          compute the right home per candidate; genuine non-zero path
-          narrowing across every group still needs more design work
-          than reusing that, and stays out of scope here.
+          group name specifically so the zero-level check above (and
+          the ':all()' partitioning below) can compute the right home
+          per candidate; genuine non-zero, non-':all()' path narrowing
+          across every group still needs more design work than reusing
+          that, and stays out of scope here.
+        - :manifest() needs one already-known manifest.json to re-read
+          in _extract_data() -- not yet threaded through for the star-
+          traversal case the way the field accessor was.
 
         So this only generalizes _discover_run_homes() (root_major=None
         skips its group filter -- it already reads the same archive-
@@ -631,30 +634,53 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # express. build_chain() above already validated ':flatten()'
         # takes no argument (Function3.check_valid()'s generic ARG_TYPES
         # check, called from build()) -- no separate check needed here.
-        # ':all()'/':groups()' stay unsupported -- RESULTS' own ':all()'
-        # already means something else entirely at star-traversal's
-        # position (see this method's own docstring), and ':groups()'
-        # (any-depth GROUP, one result per distinct value observed) has
-        # no established per-GROUP-of-named-results-groups meaning the
-        # way ':flatten()' (any-depth POOL) does -- left for if/when a
-        # real use case asks for it, same as the literal-root case's own
-        # deferred ':groups()' precedent.
+        # ':all()' -- added 2026-08-19, closing the meaning-collision
+        # settled with David (references_notes/notes/
+        # normative_reference_examples.txt, "THE ':all()' MEANING
+        # COLLISION AT STAR TRAVERSAL" section): partitions every
+        # zero-or-one-level candidate by the COMPOSITE (group,
+        # template-value) key, mirroring FilesReferenceFinder3's own
+        # already-built ':all()' star-traversal precedent exactly
+        # (there, "file_home" already embeds the named-file's own name
+        # as a prefix, so partitioning by file_home already IS a
+        # composite key -- see files_reference_finder_3.py's own
+        # _query_star_traversal docstring). Neither axis is collapsed
+        # into the other: pooling by template value alone would
+        # silently conflate two different named-results groups that
+        # happen to reuse the same subfolder name; grouping by named-
+        # results group alone would silently lose the template
+        # distinction within a group. Confirmed with David via a worked
+        # example (two groups, one template value -- "east" -- reused
+        # by both) before building this.
+        # ':groups()' stays unsupported -- the any-depth GROUP peer of
+        # this ':all()' fix has no established per-GROUP-of-named-
+        # results-groups meaning yet, left for if/when a real use case
+        # asks for it, same as the literal-root case's own deferred
+        # ':groups()' precedent.
+        all_call = next((f for f in built if f.name == "all"), None)
         flatten_call = next((f for f in built if f.name == "flatten"), None)
+        if all_call is not None and flatten_call is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not support combining "
+                "':all()'/':flatten()' -- each is its own depth/grouping "
+                "choice, not to be combined with another."
+            )
         non_pointers = [
             f
             for f in built
             if f.ROLE != Function3.POINTER
             and f is not field_call
             and f is not flatten_call
+            and f is not all_call
         ]
         if non_pointers:
             raise ReferenceException3(
                 f"ResultsReferenceFinder3 does not yet support "
                 f":{non_pointers[0].name}() combined with '*' traversal -- "
                 "only a bare pointer (:first()/:last()/:index(n)), "
-                "optionally combined with ':flatten()' and/or a run-level "
-                "field-accessor function (e.g. :uuid()), is supported so "
-                "far."
+                "optionally combined with ':all()'/':flatten()' and/or a "
+                "run-level field-accessor function (e.g. :uuid()), is "
+                "supported so far."
             )
         pointer = self._pointer_from_calls(calls)
         if pointer is None:
@@ -663,6 +689,31 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 ":last()/:index(n)) when traversing every named-results "
                 "group with '*'."
             )
+
+        if all_call is not None:
+            # exactly one level, wildcarded -- the SAME [Star3()]
+            # restriction bare ':all()' already applies for one literal
+            # group, just computed per candidate's own group home.
+            partitioned = []
+            for rh, group in self._discover_run_homes(None):
+                home = self.csvpaths.results_manager.get_named_results_home(
+                    group
+                )
+                if self._matches_prefix(rh, home, [Star3()]):
+                    partitioned.append((rh, (group, self._group_key(rh, home))))
+            groups: dict = {}
+            for rh, key in partitioned:
+                groups.setdefault(key, []).append(rh)
+            selected_run_homes = []
+            for key in sorted(groups):
+                candidates = sorted(groups[key], key=self._run_dir_sort_key)
+                selected = self._apply_pointer(pointer, candidates)
+                if selected is not None:
+                    selected_run_homes.append(selected)
+            results = []
+            for run_dir in selected_run_homes:
+                results.extend(self._results_for_run(run_dir, None, False))
+            return ReferenceResults3(results=results)
 
         if flatten_call is not None:
             # any depth, every group -- _discover_run_homes(None) already

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -527,50 +527,35 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
     def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
         """root_major == "*" -- query across every named-results group,
-        not just one. Deliberately narrow: only a bare pointer
-        (:first()/:last()/:index(n)), optionally combined with a run-
-        level field-accessor function (e.g. :uuid(), :named_paths_name()
-        -- added 2026-08-18, see this method's own field_call comment
-        below), ':flatten()' (any-depth pooling across every group --
-        added 2026-08-18, see this method's own flatten_call comment
-        below), or ':all()' (exactly-one-level GROUPING across every
-        group -- added 2026-08-19, see this method's own all_call
-        comment below) -- still no literal/'*' path narrowing, no
-        name_three, no :manifest(). A bare pointer with no ':flatten()'/
-        ':all()' here means the same zero-level-only ("direct children
-        of each run's own group's home") restriction the literal-root
-        query() case now applies -- settled 2026-08-10, see that
-        method's own comments. Two things make the remaining wider
-        cases genuinely harder here, not just unbuilt yet (unlike
-        files/csvpaths, where the same shapes were straightforward
-        generalizations):
+        not just one. Mirrors query()'s own dispatch tree (bare
+        function-only / prefix+':flatten()' / prefix+':all()' /
+        prefix+':groups()' / plain literal-'*' path), just computing
+        each candidate's own home per its own group (via
+        _discover_run_homes(None), which keeps each pair's group name
+        specifically for this) instead of one fixed home -- added
+        2026-08-19, closing the "literal/'*' path narrowing" gap this
+        method used to reject outright. ':groups()' (any-depth GROUP)
+        stays unsupported here, same as bare ':groups()' already was --
+        no established per-GROUP-of-named-results-groups meaning exists
+        for it yet, left for if/when a real use case asks. name_three
+        (an instance selector) is now supported too (added 2026-08-19)
+        -- _results_for_run() already does the identity/':all()'/range
+        selection entirely from a real run directory, independent of
+        group, so it composes with every shape above unchanged; the one
+        real design point is the ':all()'-GROUPING-plus-content-
+        accessor case, see _star_group_and_reduce()'s own comment.
+        :manifest() stays unsupported -- needs one already-known
+        manifest.json to re-read in _extract_data(), which cannot yet
+        tell a Rule-1a/1b global-ledger result apart from a traversal-
+        selected run directory (see _extract_data()'s own has_manifest
+        branch) -- a separate, still-open gap, not attempted here.
 
-        - Literal/'*' path narrowing (_matches_prefix) needs a
-          candidate's own group's home directory to compute a relative
-          match -- a bare run_home string, once pooled from
-          _discover_run_homes(), no longer carries which group it came
-          from on its own. _discover_run_homes() now keeps each pair's
-          group name specifically so the zero-level check above (and
-          the ':all()' partitioning below) can compute the right home
-          per candidate; genuine non-zero, non-':all()' path narrowing
-          across every group still needs more design work than reusing
-          that, and stays out of scope here.
-        - :manifest() needs one already-known manifest.json to re-read
-          in _extract_data() -- not yet threaded through for the star-
-          traversal case the way the field accessor was.
-
-        So this only generalizes _discover_run_homes() (root_major=None
-        skips its group filter -- it already reads the same archive-
-        wide ledger Rule 1a/1b use, so no separate group-name
-        enumeration is needed at all) and reuses _results_for_run()'s
-        existing no-name_three case unchanged. One real design
-        decision, independent of the zero-level change: chronological
-        order across every group cannot use a full-path string sort the
-        way one group's own query() case can get away with (different
-        groups' run directories live under different prefixes, so a
-        full-path sort would sort by group name first, not by
-        timestamp) -- _run_dir_sort_key() extracts just the trailing
-        directory-name segment, AND handles that segment's own
+        Chronological order across every group cannot use a full-path
+        string sort the way one group's own query() case can get away
+        with (different groups' run directories live under different
+        prefixes, so a full-path sort would sort by group name first,
+        not by timestamp) -- _run_dir_sort_key() extracts just the
+        trailing directory-name segment, AND handles that segment's own
         disambiguating "_N" suffix numerically rather than as a string
         (see this module's own docstring for why that suffix
         specifically cannot be sorted as a plain string).
@@ -581,82 +566,185 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 "ResultsReferenceFinder3 does not support the '#worksheet' "
                 "marker (name_two) -- it is files-only."
             )
-        if not self._is_bare_function_only(name_one):
+        identity, match_all, accessor, _, range_bounds = self._name_three_selector(
+            reference.name_three
+        )
+        if match_all and accessor is not None:
+            # same "more than one entity" rule the literal-root case
+            # already enforces, unconditionally, regardless of run
+            # count -- :all() at name_three means every instance in
+            # whichever run(s) match, each with its own separate well-
+            # known file on disk.
             raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support path "
-                "narrowing combined with '*' traversal -- only a bare "
-                "pointer (:first()/:last()/:index(n)) is supported so "
-                "far, e.g. '$*.results.:last()'."
+                "ResultsReferenceFinder3 requires a specific statement "
+                "identity, not :all(), to read full well-known-file "
+                "content -- resolving full content always touches "
+                "exactly one entity."
             )
-        if reference.name_three is not None:
+
+        if self._is_bare_function_only(name_one):
+            calls = self._combined_name_one_calls(name_one)
+            pointer, all_call, flatten_call = self._star_run_selector_chain(calls)
+            if all_call is not None:
+                # exactly one level, wildcarded -- the SAME [Star3()]
+                # restriction bare ':all()' already applies for one
+                # literal group, just computed per candidate's own
+                # group home. Partitions by the COMPOSITE (group,
+                # template-value) key -- see this method's own
+                # docstring and normative_reference_examples.txt's "THE
+                # ':all()' MEANING COLLISION AT STAR TRAVERSAL" section.
+                partitioned = []
+                for rh, group in self._discover_run_homes(None):
+                    home = self.csvpaths.results_manager.get_named_results_home(
+                        group
+                    )
+                    if self._matches_prefix(rh, home, [Star3()]):
+                        partitioned.append(
+                            (rh, (group, self._group_key(rh, home)))
+                        )
+                return self._star_group_and_reduce(
+                    partitioned, pointer, identity, match_all, range_bounds, accessor
+                )
+            if flatten_call is not None:
+                # any depth, every group -- _discover_run_homes(None)
+                # already discovers across every group with no depth
+                # restriction of its own (the zero-level restriction in
+                # the else branch below is applied AFTER discovery, by
+                # the _matches_prefix filter, not by discovery itself),
+                # so no separate any-depth gathering logic is needed
+                # here.
+                run_homes = [rh for rh, _ in self._discover_run_homes(None)]
+            else:
+                # zero-level (direct children of each run's own group's
+                # home) only -- same restriction the literal-root
+                # query() case now applies to a plain bare pointer,
+                # settled 2026-08-10.
+                run_homes = [
+                    rh
+                    for rh, group in self._discover_run_homes(None)
+                    if self._matches_prefix(
+                        rh,
+                        self.csvpaths.results_manager.get_named_results_home(group),
+                        [],
+                    )
+                ]
+            return self._star_pool_and_reduce(
+                run_homes, pointer, identity, match_all, range_bounds, accessor
+            )
+
+        if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "flatten":
+            # a literal/wildcard prefix, then ':flatten()' as the last
+            # path segment, e.g. "beta/:flatten():last()" -- matches
+            # this prefix (relative to each candidate's OWN group home),
+            # then anything, at any remaining depth.
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':flatten()' does not take "
+                    "an argument."
+                )
+            prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
+            calls = list(name_one.functions)
+            pointer, _, _ = self._star_run_selector_chain(calls)
+            run_homes = [
+                rh
+                for rh, group in self._discover_run_homes(None)
+                if self._matches_prefix_at_least(
+                    rh,
+                    self.csvpaths.results_manager.get_named_results_home(group),
+                    prefix_pattern,
+                )
+            ]
+            return self._star_pool_and_reduce(
+                run_homes, pointer, identity, match_all, range_bounds, accessor
+            )
+
+        if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "all":
+            # a literal/wildcard prefix, then ':all()' as the last path
+            # segment, e.g. "beta/:all():last()" -- matches exactly one
+            # level beyond the prefix (relative to each candidate's OWN
+            # group home), grouped by the COMPOSITE (group, observed-
+            # value-at-that-position) key, same as the bare case above.
+            if name_one.path[-1].arg is not None:
+                raise ReferenceException3(
+                    "ResultsReferenceFinder3's ':all()' does not take an "
+                    "argument."
+                )
+            prefix = self._compile_path_pattern(name_one.path[:-1])
+            pattern = prefix + [Star3()]
+            calls = list(name_one.functions)
+            pointer, _, _ = self._star_run_selector_chain(calls)
+            partitioned = []
+            for rh, group in self._discover_run_homes(None):
+                home = self.csvpaths.results_manager.get_named_results_home(group)
+                if self._matches_prefix(rh, home, pattern):
+                    partitioned.append(
+                        (
+                            rh,
+                            (
+                                group,
+                                self._group_key(
+                                    rh, home, prefix_len=len(pattern) - 1
+                                ),
+                            ),
+                        )
+                    )
+            return self._star_group_and_reduce(
+                partitioned, pointer, identity, match_all, range_bounds, accessor
+            )
+
+        if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
+            -1
+        ].name == "groups":
             raise ReferenceException3(
-                "ResultsReferenceFinder3 does not yet support name_three "
-                "(an instance selector) combined with '*' traversal."
+                "ResultsReferenceFinder3 does not yet support ':groups()' "
+                "combined with '*' traversal -- no established per-GROUP-"
+                "of-named-results-groups meaning exists yet, unlike the "
+                "literal-root case's own ':groups()'."
             )
-        calls = self._combined_name_one_calls(name_one)
+
+        # plain literal/'*' path, no trailing ':flatten()'/':all()'/
+        # ':groups()' marker -- POOL mode, exact-length match (relative
+        # to each candidate's OWN group home), reduced by the pointer.
+        pattern = self._compile_path_pattern(name_one.path)
+        calls = list(name_one.functions)
+        pointer, _, _ = self._star_run_selector_chain(calls)
+        run_homes = [
+            rh
+            for rh, group in self._discover_run_homes(None)
+            if self._matches_prefix(
+                rh, self.csvpaths.results_manager.get_named_results_home(group), pattern
+            )
+        ]
+        return self._star_pool_and_reduce(
+            run_homes, pointer, identity, match_all, range_bounds, accessor
+        )
+
+    def _star_run_selector_chain(self, calls: list) -> tuple:
+        """validates a run-selecting combined function chain for '*'
+        traversal, shared by every _query_star_traversal shape (bare
+        and literal/'*'-prefixed alike) -- added 2026-08-19, factored
+        out of what used to be inline-only-for-the-bare-case logic once
+        the literal/'*'-prefixed shapes needed the identical validation.
+        Returns (pointer, all_call, flatten_call); all_call/flatten_call
+        are only ever non-None for the bare shape (calls includes
+        name_one.path[0] itself there) -- for a prefixed shape, calls is
+        just name_one.functions, and the ':all()'/':flatten()' marker
+        lives in name_one.path[-1] instead, inspected separately by the
+        caller, so it can never appear in `built` here; returning
+        None/None for those callers is correct, not a missed case.
+        A run-level field-accessor function (e.g. :uuid(),
+        :named_paths_name() -- added 2026-08-18) is exempt from the
+        non-pointer rejection below, same as ':all()'/':flatten()' are:
+        _results_for_run() already builds each candidate's
+        ReferenceResult3 from its own real run directory, independent
+        of any group-name context, so resolving a field from it needs
+        nothing star-traversal-specific."""
         built = ReferenceFunctionFactory.build_chain(calls)
-        # added 2026-08-14 -- replaces two separate, still-incomplete
-        # checks (an "all()/flatten()/manifest() by name" check and a
-        # separate field-function check) with one that actually covers
-        # every case this method's own docstring restriction implies
-        # ("only a bare pointer... is supported so far"). Confirmed via
-        # direct testing before this fix that neither replaced check
-        # actually caught everything it should have -- ':groups()' and
-        # ':from()' both silently swallowed instead of raising, the
-        # same bug class already fixed for the literal-root case above.
-        # added 2026-08-18 -- a run-level field accessor (e.g. :uuid(),
-        # :named_paths_name()) is now allowed alongside the pointer:
-        # _results_for_run() (below) already builds each candidate's
-        # ReferenceResult3 from its own real run directory, independent
-        # of any group-name context, so resolving a field from it needs
-        # nothing star-traversal-specific -- see _extract_data()'s own
-        # comment on why this "just works" once let through. Previously
-        # rejected here alongside :all()/:flatten()/:groups()/:manifest()/
-        # ':from()'/':to()', which is still narrower than that reasoning
-        # required -- David: this gap "invalidates a high-value class of
-        # scenarios" for reference expressions, which need exactly this
-        # (a scalar per matched candidate, searched across every group)
-        # to compare RESULTS against CSVPATHS/FILES at all.
-        # _find_field_function_call(built), not calls -- calls holds raw
-        # FunctionCall3 parse shapes, built holds the real constructed
-        # Function3 instances non_pointers iterates below; comparing a
-        # raw-list match against a built-list entry via "is" would never
-        # succeed, since they are different objects even for "the same"
-        # function.
         field_call = self._find_field_function_call(built)
-        # added 2026-08-18 -- ':flatten()' (any-depth pooling, mirroring
-        # its own literal-root meaning -- see is_flattened in query()
-        # above) is now also allowed alongside the pointer, for the same
-        # reason a field accessor is: David's own "orders" worked
-        # example (references_notes/notes/reference_expressions_notes.
-        # txt) needs "every run, any depth, across every group" as its
-        # left-hand side, which a zero-level-only bare pointer cannot
-        # express. build_chain() above already validated ':flatten()'
-        # takes no argument (Function3.check_valid()'s generic ARG_TYPES
-        # check, called from build()) -- no separate check needed here.
-        # ':all()' -- added 2026-08-19, closing the meaning-collision
-        # settled with David (references_notes/notes/
-        # normative_reference_examples.txt, "THE ':all()' MEANING
-        # COLLISION AT STAR TRAVERSAL" section): partitions every
-        # zero-or-one-level candidate by the COMPOSITE (group,
-        # template-value) key, mirroring FilesReferenceFinder3's own
-        # already-built ':all()' star-traversal precedent exactly
-        # (there, "file_home" already embeds the named-file's own name
-        # as a prefix, so partitioning by file_home already IS a
-        # composite key -- see files_reference_finder_3.py's own
-        # _query_star_traversal docstring). Neither axis is collapsed
-        # into the other: pooling by template value alone would
-        # silently conflate two different named-results groups that
-        # happen to reuse the same subfolder name; grouping by named-
-        # results group alone would silently lose the template
-        # distinction within a group. Confirmed with David via a worked
-        # example (two groups, one template value -- "east" -- reused
-        # by both) before building this.
-        # ':groups()' stays unsupported -- the any-depth GROUP peer of
-        # this ':all()' fix has no established per-GROUP-of-named-
-        # results-groups meaning yet, left for if/when a real use case
-        # asks for it, same as the literal-root case's own deferred
-        # ':groups()' precedent.
         all_call = next((f for f in built if f.name == "all"), None)
         flatten_call = next((f for f in built if f.name == "flatten"), None)
         if all_call is not None and flatten_call is not None:
@@ -689,62 +777,79 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 ":last()/:index(n)) when traversing every named-results "
                 "group with '*'."
             )
+        return pointer, all_call, flatten_call
 
-        if all_call is not None:
-            # exactly one level, wildcarded -- the SAME [Star3()]
-            # restriction bare ':all()' already applies for one literal
-            # group, just computed per candidate's own group home.
-            partitioned = []
-            for rh, group in self._discover_run_homes(None):
-                home = self.csvpaths.results_manager.get_named_results_home(
-                    group
-                )
-                if self._matches_prefix(rh, home, [Star3()]):
-                    partitioned.append((rh, (group, self._group_key(rh, home))))
-            groups: dict = {}
-            for rh, key in partitioned:
-                groups.setdefault(key, []).append(rh)
-            selected_run_homes = []
-            for key in sorted(groups):
-                candidates = sorted(groups[key], key=self._run_dir_sort_key)
-                selected = self._apply_pointer(pointer, candidates)
-                if selected is not None:
-                    selected_run_homes.append(selected)
-            results = []
-            for run_dir in selected_run_homes:
-                results.extend(self._results_for_run(run_dir, None, False))
-            return ReferenceResults3(results=results)
-
-        if flatten_call is not None:
-            # any depth, every group -- _discover_run_homes(None) already
-            # discovers across every group with no depth restriction of
-            # its own (the zero-level restriction below is applied AFTER
-            # discovery, by the _matches_prefix filter, not by discovery
-            # itself), so no separate any-depth gathering logic is
-            # needed here.
-            run_homes = [rh for rh, _ in self._discover_run_homes(None)]
-        else:
-            # zero-level (direct children of each run's own group's
-            # home) only -- same restriction the literal-root query()
-            # case now applies to a plain bare pointer, settled
-            # 2026-08-10. Each candidate's own group name (kept by
-            # _discover_run_homes since this is the traversal case) is
-            # needed to compute the right "home" per candidate --
-            # different groups have different homes.
-            run_homes = [
-                rh
-                for rh, group in self._discover_run_homes(None)
-                if self._matches_prefix(
-                    rh, self.csvpaths.results_manager.get_named_results_home(group), []
-                )
-            ]
+    def _star_pool_and_reduce(
+        self,
+        run_homes: list,
+        pointer,
+        identity: str | None,
+        match_all: bool,
+        range_bounds: tuple | None,
+        accessor,
+    ) -> ReferenceResults3:
+        """POOL mode's shared tail -- added 2026-08-19, alongside
+        _star_group_and_reduce(), factored out once name_three needed
+        threading through every star-traversal shape identically. No
+        "more than one candidate + content accessor" guard is needed
+        here (unlike the GROUP case) -- a pointer is always required in
+        POOL mode, so exactly one run is ever selected."""
         run_homes = sorted(run_homes, key=self._run_dir_sort_key)
         selected = self._apply_pointer(pointer, run_homes)
         if selected is None:
             return ReferenceResults3(results=[])
         return ReferenceResults3(
-            results=self._results_for_run(selected, None, False)
+            results=self._results_for_run(
+                selected, identity, match_all, range_bounds, accessor
+            )
         )
+
+    def _star_group_and_reduce(
+        self,
+        partitioned: list,
+        pointer,
+        identity: str | None,
+        match_all: bool,
+        range_bounds: tuple | None,
+        accessor,
+    ) -> ReferenceResults3:
+        """GROUP mode's shared tail (":all()", bare or literal/'*'-
+        prefixed) -- added 2026-08-19. `partitioned`: list of
+        (run_home, composite_key) pairs. Unlike POOL mode, a pointer
+        here can still select MORE than one run overall (one per
+        partition) -- so a name_three CONTENT accessor (:errors()/
+        :vars()/etc, as opposed to a poolable field accessor like
+        :uuid()) is rejected outright here, mirroring the literal-root
+        query() case's own "':all()'/':groups()' grouping does not
+        combine with :manifest() or a run-level field accessor"
+        restriction, narrowed to the piece that actually applies here:
+        a name_three CONTENT accessor reading full file content is "one
+        entity" per the same rule content accessors are held to
+        everywhere else in this file, and grouping can produce several.
+        A name_three FIELD accessor (e.g. ".invoices:uuid()") is NOT
+        rejected -- confirmed live against the already-shipped literal-
+        root precedent (":all():last().invoices:uuid()" resolves fine,
+        poolable, one result per matched run) before writing this."""
+        if accessor is not None:
+            raise ReferenceException3(
+                "ResultsReferenceFinder3 does not yet support combining "
+                "':all()' grouping with a name_three content accessor -- "
+                "resolve the grouped runs on their own first."
+            )
+        groups: dict = {}
+        for rh, key in partitioned:
+            groups.setdefault(key, []).append(rh)
+        results = []
+        for key in sorted(groups):
+            candidates = sorted(groups[key], key=self._run_dir_sort_key)
+            selected = self._apply_pointer(pointer, candidates)
+            if selected is not None:
+                results.extend(
+                    self._results_for_run(
+                        selected, identity, match_all, range_bounds, accessor
+                    )
+                )
+        return ReferenceResults3(results=results)
 
     _JSON_ACCESSOR_FILES = {
         "errors": "errors.json",

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -807,6 +807,98 @@ class TestStarTraversalGroup:
         assert set(results.uuids) == {"a-v1", "a-v2", "b-v1"}
 
 
+class TestStarTraversalHaving:
+    # ':having("identity")' combined with '*' traversal -- added
+    # 2026-08-18, alongside RESULTS' own ':flatten()' fix. Closes a
+    # real, previously-latent bug, not just a missing feature: before
+    # this fix ':having()' was never checked for at all in
+    # _query_star_traversal -- neither rejected as unsupported NOR
+    # applied -- so it was silently DROPPED (confirmed live before
+    # writing these: "$*.csvpaths.:all():having('orders')" returned
+    # EVERY group's every version, unfiltered, not just the matching
+    # ones).
+    HAVING_BY_NAME = {
+        "alpha": [
+            {
+                "group_file_path": "named_paths/alpha/group.csvpath",
+                "uuid": "a-v1",
+                "time": "2026-01-01T00:00:00+00:00",
+                "named_paths_identities": ["orders"],
+                "named_paths_name": "alpha",
+            },
+            {
+                "group_file_path": "named_paths/alpha/group.csvpath",
+                "uuid": "a-v2",
+                "time": "2026-01-02T00:00:00+00:00",
+                "named_paths_identities": ["other"],
+                "named_paths_name": "alpha",
+            },
+        ],
+        "beta": [
+            {
+                "group_file_path": "named_paths/beta/group.csvpath",
+                "uuid": "b-v1",
+                "time": "2026-01-03T00:00:00+00:00",
+                "named_paths_identities": ["other"],
+                "named_paths_name": "beta",
+            }
+        ],
+    }
+
+    def test_grouped_having_filters_out_non_matching_versions(self):
+        # the actual bug this closes: without the fix, this returned all
+        # three versions, unfiltered -- only a-v1 actually has "orders".
+        results = _finder(
+            "$*.csvpaths.:all():having(\"orders\")", by_name=self.HAVING_BY_NAME
+        ).query()
+        assert results.uuids == ["a-v1"]
+
+    def test_grouped_having_with_pointer_gives_one_per_matching_group(self):
+        # beta has no version with "orders" at all -- it contributes
+        # nothing, not an empty/None placeholder.
+        results = _finder(
+            "$*.csvpaths.:having(\"orders\"):all():last()",
+            by_name=self.HAVING_BY_NAME,
+        ).query()
+        assert results.uuids == ["a-v1"]
+
+    def test_flatten_having_pools_filtered_versions_across_groups(self):
+        # not grouped (no ':all()') -- filtered pool across every group,
+        # reduced by the pointer, same as the ungrouped/flatten mode
+        # already does for the unfiltered case.
+        results = _finder(
+            "$*.csvpaths.:having(\"orders\"):last()", by_name=self.HAVING_BY_NAME
+        ).query()
+        assert results.uuids == ["a-v1"]
+
+    def test_having_combined_with_a_field_accessor_also_works(self):
+        results = _finder(
+            "$*.csvpaths.:having(\"orders\"):all():last():named_paths_name()",
+            by_name=self.HAVING_BY_NAME,
+        ).resolve()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "a-v1"
+        assert results.results[0].data == "alpha"
+
+    def test_having_with_no_matching_version_anywhere_is_empty(self):
+        results = _finder(
+            "$*.csvpaths.:all():having(\"nope\")", by_name=self.HAVING_BY_NAME
+        ).query()
+        assert results.results == []
+
+    def test_bare_having_alone_still_requires_a_pointer_or_all(self):
+        # deliberately unchanged -- a bare ':having()' with no pointer
+        # and no ':all()' does not get a new "unreduced flatten" meaning
+        # of its own; it falls into the same pre-existing "requires a
+        # pointer" rule flatten mode already enforces for a plain bare
+        # pointer, consistent with FLATTEN never having an "unreduced"
+        # form for csvpaths' own star traversal.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.csvpaths.:having(\"orders\")", by_name=self.HAVING_BY_NAME
+            ).query()
+
+
 class TestDefinitionFunction:
     # ":definition()" mirrors ":manifest()" exactly -- same bare, sole-
     # content shape, same query()/_extract_data() routing -- except

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1814,10 +1814,27 @@ class TestGlobalArchiveLedger:
         results = _finder("$*.results.:last()", acme_archive).query()
         assert results.results == []
 
-    def test_star_with_path_narrowing_is_still_not_supported(self, acme_archive):
-        finder = _finder("$*.results.customers/2025:last()", acme_archive)
-        with pytest.raises(ReferenceException3):
-            finder.query()
+    def test_star_with_a_literal_path_prefix_now_works(self, acme_archive):
+        # closes the path-narrowing gap (2026-08-19) -- matches
+        # acme_archive's own "customers/2025" template, relative to
+        # acme's own group home, the same way the literal-root case
+        # already does, just discovered via '*' traversal instead.
+        results = _finder(
+            "$*.results.customers/2025:last()", acme_archive
+        ).query()
+        assert results.results[0].uuid == "run2-uuid"
+
+    def test_star_with_a_literal_path_prefix_excludes_non_matching_groups(
+        self, two_group_archive
+    ):
+        # two_group_archive's runs are all flat (zero-level) -- a
+        # literal "customers/2025" prefix matches neither group, so
+        # this correctly finds nothing rather than falling back to
+        # some other group's run.
+        results = _finder(
+            "$*.results.customers/2025:last()", two_group_archive
+        ).query()
+        assert results.results == []
 
 
 class TestGlobalArchiveLedgerOrdinalIndexing:
@@ -1896,18 +1913,55 @@ class TestStarTraversal:
         results = _finder("$*.results.:index(1)", two_group_archive).query()
         assert results.results[0].uuid == "acme-run2-uuid"
 
-    def test_all_is_not_yet_supported(self, two_group_archive):
-        # results' own :all() already means "every instance within one
-        # run" (name_three) -- no syntactic home for group-by-group
-        # traversal semantics exists yet, unlike files/csvpaths.
+    def test_bare_all_with_no_pointer_still_requires_a_pointer(
+        self, two_group_archive
+    ):
+        # ':all()' grouping DOES have a home in star traversal now (see
+        # TestAllGroupingStarTraversal) -- unlike ':manifest()'/
+        # name_three, this was never a "no meaning exists" restriction.
+        # What still raises is the SAME "no pointer" rule ':flatten()'
+        # is also held to in traversal mode -- a bare ':all()' with no
+        # pointer does not get an "unreduced, list everything" meaning
+        # of its own here, consistent with FLATTEN mode's own no-
+        # pointer restriction in this same method.
         with pytest.raises(ReferenceException3):
             _finder("$*.results.:all()", two_group_archive).query()
 
-    def test_name_three_combined_with_traversal_is_not_yet_supported(
+    def test_name_three_combined_with_traversal_now_works(self, tmp_path):
+        # closes the name_three gap (2026-08-19) -- _results_for_run()
+        # already does the identity selection entirely from a real run
+        # directory, independent of group, so it composes with a bare
+        # pointer here unchanged. widgets' run is the true global-
+        # latest, so this proves the run-selection AND the instance
+        # selection within it both resolved correctly, not just one.
+        acme_run = _make_run(
+            tmp_path / "acme",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {"invoices": "acme-invoices-uuid"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets",
+            "2026-01-03_00-00-00",
+            "widgets-run",
+            {"invoices": "widgets-invoices-uuid"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder(
+            "$*.results.:last().invoices", str(tmp_path)
+        ).query()
+        assert results.results[0].uuid == "widgets-invoices-uuid"
+
+    def test_name_three_with_no_matching_identity_is_empty_not_an_error(
         self, two_group_archive
     ):
-        with pytest.raises(ReferenceException3):
-            _finder("$*.results.:last().0", two_group_archive).query()
+        # two_group_archive's runs have no instances at all -- a
+        # literal identity that matches nothing correctly gives an
+        # empty result, not an error.
+        results = _finder("$*.results.:last().0", two_group_archive).query()
+        assert results.results == []
 
     def test_field_accessor_combined_with_star_traversal_now_works(self, tmp_path):
         # closes the gap ReferenceExpression3 needed -- a run-level
@@ -1969,6 +2023,178 @@ class TestStarTraversal:
         assert result.results[0].data is None
 
 
+class TestStarTraversalPathNarrowingAndNameThree:
+    # closes the "literal/'*' path narrowing" and "name_three" gaps in
+    # _query_star_traversal -- added 2026-08-19, alongside the ':all()'
+    # meaning-collision fix. Thorough coverage of the literal/'*'-
+    # prefixed shapes (prefix+':flatten()', prefix+':all()') and of
+    # name_three (an instance selector) composing with every run-
+    # selection shape, since _results_for_run() already did the
+    # identity/':all()'/range selection entirely group-independently.
+    def test_prefixed_flatten_pools_any_depth_beyond_prefix_across_groups(
+        self, tmp_path
+    ):
+        acme_shallow = _make_run(
+            tmp_path / "acme" / "beta", "2026-01-01_00-00-00", "acme-shallow", {}
+        )
+        acme_deep = _make_run(
+            tmp_path / "acme" / "beta" / "x" / "y",
+            "2026-01-02_00-00-00",
+            "acme-deep",
+            {},
+        )
+        widgets_deep = _make_run(
+            tmp_path / "widgets" / "beta" / "z",
+            "2026-01-03_00-00-00",
+            "widgets-deep",
+            {},
+        )
+        widgets_other = _make_run(
+            tmp_path / "widgets" / "gamma",
+            "2026-01-04_00-00-00",
+            "widgets-other",
+            {},
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {
+                "acme": [acme_shallow, acme_deep],
+                "widgets": [widgets_deep, widgets_other],
+            },
+        )
+        # widgets-other (gamma) is chronologically latest overall, but
+        # does not match the "beta" prefix -- proves the prefix is
+        # actually filtering, not just falling back to global latest.
+        results = _finder(
+            "$*.results.beta/:flatten():last()", str(tmp_path)
+        ).query()
+        assert results.results[0].uuid == "widgets-deep"
+
+    def test_prefixed_all_partitions_by_composite_key_beyond_prefix(
+        self, tmp_path
+    ):
+        acme_x = _make_run(
+            tmp_path / "acme" / "beta" / "x", "2026-01-01_00-00-00", "acme-x", {}
+        )
+        acme_y = _make_run(
+            tmp_path / "acme" / "beta" / "y", "2026-01-02_00-00-00", "acme-y", {}
+        )
+        widgets_x = _make_run(
+            tmp_path / "widgets" / "beta" / "x",
+            "2026-01-03_00-00-00",
+            "widgets-x",
+            {},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_x, acme_y], "widgets": [widgets_x]}
+        )
+        # "x" is reused by both groups on purpose -- same crux as the
+        # bare ':all()' meaning-collision fixture, proving the prefixed
+        # shape ALSO partitions by (group, value), not value alone.
+        results = _finder(
+            "$*.results.beta/:all():last()", str(tmp_path)
+        ).query()
+        assert sorted(results.uuids) == ["acme-x", "acme-y", "widgets-x"]
+
+    def test_all_grouping_with_name_three_content_accessor_is_rejected(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme" / "east",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {"invoices": "acme-invoices"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [acme_run])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.results.:all():last().invoices:errors()", str(tmp_path)
+            ).query()
+
+    def test_all_grouping_with_name_three_field_accessor_is_poolable(
+        self, tmp_path
+    ):
+        # David's own confirmed example: "$*.results.:all():last()
+        # .invoices:uuid()" can find multiple runs, each contributing
+        # its own "invoices" statement's uuid -- a list of zero or more
+        # UUIDs, one per matched run that actually has that identity.
+        acme_run = _make_run(
+            tmp_path / "acme" / "east",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {"invoices": "acme-invoices"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets" / "east",
+            "2026-01-02_00-00-00",
+            "widgets-run",
+            {"invoices": "widgets-invoices"},
+        )
+        # gamma has no "invoices" statement at all -- contributes
+        # nothing, not an error/None placeholder.
+        gamma_run = _make_run(
+            tmp_path / "gamma" / "east",
+            "2026-01-03_00-00-00",
+            "gamma-run",
+            {"other": "gamma-other"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {"acme": [acme_run], "widgets": [widgets_run], "gamma": [gamma_run]},
+        )
+        results = _finder(
+            "$*.results.:all():last().invoices:uuid()", str(tmp_path)
+        ).resolve()
+        assert sorted(r.data for r in results.results) == [
+            "acme-invoices",
+            "widgets-invoices",
+        ]
+
+    def test_all_at_both_name_one_and_name_three_multiplies_correctly(
+        self, tmp_path
+    ):
+        # "$*.results.:all():last().:all():uuid()" -- :all() at name_one
+        # selects one run per (group, template) partition, :all() at
+        # name_three then pools every instance WITHIN each of those --
+        # a real two-level fan-out, not a single flat list.
+        acme_run = _make_run(
+            tmp_path / "acme" / "east",
+            "2026-01-01_00-00-00",
+            "acme-run",
+            {"invoices": "acme-invoices", "receipts": "acme-receipts"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets" / "east",
+            "2026-01-02_00-00-00",
+            "widgets-run",
+            {"invoices": "widgets-invoices"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder(
+            "$*.results.:all():last().:all():uuid()", str(tmp_path)
+        ).resolve()
+        assert sorted(r.data for r in results.results) == [
+            "acme-invoices",
+            "acme-receipts",
+            "widgets-invoices",
+        ]
+
+    def test_flatten_with_a_specific_name_three_identity_works(self, tmp_path):
+        acme_deep = _make_run(
+            tmp_path / "acme" / "customers" / "2025",
+            "2026-01-01_00-00-00",
+            "acme-deep",
+            {"invoices": "acme-invoices"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [acme_deep])
+        results = _finder(
+            "$*.results.:flatten():last().invoices", str(tmp_path)
+        ).query()
+        assert results.results[0].uuid == "acme-invoices"
+
+
 class TestPositionEnforcement:
     # ReferenceFinder3._check_position() -- added 2026-08-14, the
     # enforced replacement for the scattered "is this recognized"
@@ -2017,10 +2243,18 @@ class TestPositionEnforcement:
 
 
 class TestScopeLimits:
-    def test_star_root_major_not_yet_supported(self, acme_archive):
-        finder = _finder("$*.results.customers/2025:last()", acme_archive)
+    def test_manifest_combined_with_traversal_still_not_yet_supported(
+        self, two_group_archive
+    ):
+        # a real, still-open, separate gap -- see _extract_data()'s own
+        # has_manifest comment for why: it cannot yet tell a Rule-1a/1b
+        # global-ledger result apart from a traversal-selected run
+        # directory, unlike the field accessor/':all()'/':flatten()'
+        # gaps already closed.
         with pytest.raises(ReferenceException3):
-            finder.query()
+            _finder(
+                "$*.results.:all():last():manifest()", two_group_archive
+            ).query()
 
     def test_name_two_worksheet_marker_not_supported(self, acme_archive):
         finder = _finder(

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -375,11 +375,66 @@ class TestFlatten:
                 '$acme.results.beta/:flatten("x"):last()', str(tmp_path)
             ).query()
 
-    def test_flatten_combined_with_traversal_is_not_yet_supported(
+    def test_flatten_combined_with_traversal_pools_any_depth_across_every_group(
+        self, tmp_path
+    ):
+        # closes a real gap (fixed 2026-08-18, alongside CSVPATHS'
+        # analogous ':having()' fix) -- unlike two_group_archive
+        # (deliberately both-flat, to prove cross-group pooling by
+        # time), this fixture has genuine depth variance -- acme's
+        # latest run is nested, widgets' only run is flat -- proving
+        # ':flatten()' finds the true global-latest regardless of depth
+        # AND regardless of which group it belongs to.
+        acme_base = tmp_path / "acme"
+        acme_flat = _make_run(acme_base, "2026-01-01_00-00-00", "acme-flat", {})
+        acme_deep = _make_run(
+            acme_base / "customers" / "2025", "2026-01-05_00-00-00", "acme-deep", {}
+        )
+        widgets_base = tmp_path / "widgets"
+        widgets_run = _make_run(
+            widgets_base, "2026-01-03_00-00-00", "widgets-run", {}
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {"acme": [acme_flat, acme_deep], "widgets": [widgets_run]},
+        )
+        # a bare pointer (zero-level only) misses acme's own deep run
+        # entirely and gives widgets' instead -- confirms ':flatten()'
+        # below is doing real work, not just passing through unchanged.
+        bare = _finder("$*.results.:last()", str(tmp_path)).query()
+        assert bare.results[0].uuid == "widgets-run"
+
+        flattened = _finder(
+            "$*.results.:flatten():last()", str(tmp_path)
+        ).query()
+        assert flattened.results[0].uuid == "acme-deep"
+
+    def test_flatten_combined_with_a_field_accessor_also_works(self, tmp_path):
+        base = tmp_path / "acme"
+        deep_run = _make_run(
+            base / "customers" / "2025", "2026-01-01_00-00-00", "deep-uuid", {}
+        )
+        _write_json(
+            Path(deep_run) / "manifest.json",
+            {"run_uuid": "deep-uuid", "named_paths_name": "acme"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [deep_run])
+        results = _finder(
+            "$*.results.:flatten():last():named_paths_name()", str(tmp_path)
+        ).resolve()
+        assert results.results[0].uuid == "deep-uuid"
+        assert results.results[0].data == "acme"
+
+    def test_all_grouping_combined_with_traversal_is_still_not_yet_supported(
         self, two_group_archive
     ):
+        # unlike ':flatten()', ':all()' at star-traversal's own position
+        # still means something else entirely (RESULTS' own name_three
+        # ':all()', or the literal-root one-level grouping) -- this
+        # remains unsupported, a real, separate, still-open restriction,
+        # not loosened by this fix.
         with pytest.raises(ReferenceException3):
-            _finder("$*.results.:flatten():last()", two_group_archive).query()
+            _finder("$*.results.:all():last()", two_group_archive).query()
 
 
 class TestAllGrouping:

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -425,16 +425,79 @@ class TestFlatten:
         assert results.results[0].uuid == "deep-uuid"
         assert results.results[0].data == "acme"
 
-    def test_all_grouping_combined_with_traversal_is_still_not_yet_supported(
-        self, two_group_archive
+    def test_all_grouping_partitions_by_composite_group_and_template_key(
+        self, tmp_path
     ):
-        # unlike ':flatten()', ':all()' at star-traversal's own position
-        # still means something else entirely (RESULTS' own name_three
-        # ':all()', or the literal-root one-level grouping) -- this
-        # remains unsupported, a real, separate, still-open restriction,
-        # not loosened by this fix.
+        # closes the ':all()' meaning-collision (settled 2026-08-19 with
+        # David via a worked example -- see "THE ':all()' MEANING
+        # COLLISION AT STAR TRAVERSAL" in references_notes/notes/
+        # normative_reference_examples.txt) -- mirrors
+        # FilesReferenceFinder3's own already-built ':all()' star-
+        # traversal precedent: partition by the COMPOSITE (group,
+        # template-value) key, not group alone or template alone.
+        # acme has two "east" runs and one "west" run; widgets has one
+        # "east" run -- "east" is reused across BOTH groups on purpose,
+        # the crux of the ambiguity this fixture proves is resolved
+        # correctly (neither collapsed into the other).
+        acme_east_1 = _make_run(
+            tmp_path / "acme" / "east", "2026-01-01_00-00-00", "acme-east-1", {}
+        )
+        acme_east_2 = _make_run(
+            tmp_path / "acme" / "east", "2026-01-03_00-00-00", "acme-east-2", {}
+        )
+        acme_west_1 = _make_run(
+            tmp_path / "acme" / "west", "2026-01-02_00-00-00", "acme-west-1", {}
+        )
+        widgets_east_1 = _make_run(
+            tmp_path / "widgets" / "east",
+            "2026-01-04_00-00-00",
+            "widgets-east-1",
+            {},
+        )
+        _write_archive_manifest_multi(
+            tmp_path,
+            {
+                "acme": [acme_east_1, acme_east_2, acme_west_1],
+                "widgets": [widgets_east_1],
+            },
+        )
+        results = _finder("$*.results.:all():last()", str(tmp_path)).query()
+        # 3 results, not 2 -- pooling by template value alone would have
+        # conflated acme's and widgets' "east" runs into one group
+        # (giving widgets-east-1, the true latest, and losing acme-
+        # east-2 entirely); grouping by named-results-group alone would
+        # have lost the east/west distinction within acme (giving
+        # acme-east-2 as acme's one "last", never surfacing acme-west-1
+        # at all).
+        assert sorted(results.uuids) == [
+            "acme-east-2",
+            "acme-west-1",
+            "widgets-east-1",
+        ]
+
+    def test_all_combined_with_flatten_is_rejected(self, two_group_archive):
+        # each is its own depth/grouping choice -- same mutual-exclusion
+        # rule the literal-root case already enforces.
         with pytest.raises(ReferenceException3):
-            _finder("$*.results.:all():last()", two_group_archive).query()
+            _finder(
+                "$*.results.:all():flatten():last()", two_group_archive
+            ).query()
+
+    def test_all_combined_with_a_field_accessor_also_works(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme" / "east", "2026-01-01_00-00-00", "acme-east", {}
+        )
+        _write_json(
+            Path(acme_run) / "manifest.json",
+            {"run_uuid": "acme-east", "named_paths_name": "acme"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [acme_run])
+        results = _finder(
+            "$*.results.:all():last():named_paths_name()", str(tmp_path)
+        ).resolve()
+        assert len(results.results) == 1
+        assert results.results[0].uuid == "acme-east"
+        assert results.results[0].data == "acme"
 
 
 class TestAllGrouping:


### PR DESCRIPTION
## Summary
Closes the two remaining gaps noted as follow-up in #253's own notes-doc update (`references_notes/notes/reference_expressions_notes.txt`) -- the specific reason `ReferenceExpression3`'s "orders" worked example still needed a sub-expression workaround even after #253 fixed plain field-accessor support: CSVPATHS' "every group with an 'orders' statement" right side needs `:having()`+field-accessor, and RESULTS' "every run, any depth" left side needs `:flatten()`+field-accessor, in `'*'` traversal. Neither is a bare pointer/`:all()`, so #253's narrower fix did not cover them.

## CSVPATHS -- `:having()` combined with `'*'` traversal
`:having("identity")` now filters each group's own manifest down to versions actually containing that identity, in the same position it already occupies in `_resolve_versions()`'s single-group precedent -- before either mode's own pointer/grouping reduction.

This closes a real, **previously-latent bug**, not just a missing feature: `:having()` was never checked for at all in `_query_star_traversal` before this fix -- neither rejected as unsupported NOR applied -- so it was silently **dropped**. Confirmed live before writing anything:
```
"$*.csvpaths.:all():having('orders')" returned every group's every version, unfiltered.
```
A bare `:having()` alone (no pointer, no `:all()`) deliberately still raises "requires a pointer" -- this fix does not invent a new "unreduced flatten" meaning that flatten mode does not otherwise have for CSVPATHS.

## RESULTS -- `:flatten()` combined with `'*'` traversal
`:flatten()` now pools every group's runs at any depth (not just the zero-level-only restriction a bare pointer still applies) into one combined list before the pointer reduces it, mirroring its own literal-root, single-group meaning. `_discover_run_homes(None)` already discovers across every group with no depth restriction of its own, so no new gathering logic was needed -- only routing to it instead of the zero-level-filtered candidate set when `:flatten()` is present.

## Both combine with #253's field accessor
Confirmed via new tests that both fixes compose cleanly with the run/version-level field accessor #253 added, since neither cares about the other's concern (which runs/versions are candidates vs. what to read off the one selected). `:all()` (CSVPATHS' own grouping trigger) and RESULTS' own `:all()`/`:groups()` stay unsupported in traversal -- real, separate, still-open restrictions, not touched here.

## Test plan
- [x] `test_csvpaths_reference_finder_3.py` -- 6 new tests (`TestStarTraversalHaving`): grouped filtering, the silent-drop bug this closes, flatten-mode filtering, field-accessor combination, no-match-anywhere, bare `:having()` still requiring a pointer
- [x] `test_results_reference_finder_3.py` -- replaced the stale `test_flatten_combined_with_traversal_is_not_yet_supported` (which now failed to raise, confirming the fix works) with 3 positive tests: any-depth pooling across groups using a fixture with genuine depth variance (not `two_group_archive`, which is deliberately both-flat), field-accessor combination, confirming `:all()` combined with traversal still correctly raises for its own unrelated reason
- [x] `tests/references/` -- 1055 passed
- [x] Full suite -- 2643 passed, 11 failed (known SFTP/S3/Nos baseline, unrelated)

## Not in this PR
PR #252's own `test_reference_expression_3.py` (`_left_side`/`_right_side` helpers) still uses the sub-expression workaround for the "orders" example, even though both underlying gaps are now closed -- that file lives on #252's own branch. Once this PR merges, #252's branch can pull it in and switch to real `'*'` traversal on both sides, matching the pattern already used to bring #253 into #252 (mirroring the "orders" numbers should stay identical either way, which would be worth confirming directly). Left as deliberate follow-up rather than bundled here, so this PR stays focused on the Finder-level fix.
