### PR TITLE
Support :home()/:definition() during FILES star traversal

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -551,6 +551,34 @@ class FilesReferenceFinder3(ReferenceFinder3):
         supported -- those all assume exactly one already-known manifest
         to re-read in _extract_data(), which does not hold when a result
         could have come from any of several named-files' manifests.
+
+        ':home()' and ':definition()' as name_one's own content -- added
+        2026-08-27 (FILES '*' traversal generalization bucket-list
+        entry), closing three of that entry's four identified gaps (the
+        fourth, a predicate argument to filter by, is separately unbuilt
+        -- see the predicate-argument bucket-list entry). Two independent
+        shapes, both METADATA_FILE (definition.json is never versioned,
+        so there is no "which version" left for name_three to narrow --
+        combining either shape with name_three is rejected):
+        - bare ':definition()' alone -- every named-file's own
+          definition.json, one result per named-file, regardless of
+          whether it has any zero-level registration at all.
+        - ':home()' with ':definition()' chained onto it -- the SAME
+          per-named-file definition.json lookup, but FILTERED to only
+          named-files that have at least one zero-level ("no template")
+          registration, per the concrete worked example that motivated
+          this ("$*.files.:home():definition(:on_arrival(:not_none()))"
+          -- "which named-files have on_arrival set," restricted to
+          plain, non-templated registrations). ':home()' here is a
+          filter, not the placeholder-value role it plays bare -- it has
+          nothing to be a placeholder FOR, since ':definition()' does not
+          vary by version/path the way a pointer's target would.
+        A bare ':home()' with nothing chained onto it (no ':definition()')
+        is a separate, third shape -- see the is_home branch below -- and
+        falls through to the ordinary candidate/pointer machinery every
+        other bare shape uses, since it is FIRST_PARTY-style path
+        narrowing (an empty, zero-level pattern), not a metadata-file
+        read.
         """
         name_one = reference.name_one
         if name_one.name_two is not None:
@@ -558,6 +586,41 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "FilesReferenceFinder3 does not yet support the '#worksheet' "
                 "marker (name_two)."
             )
+        is_home = self._is_home_prefixed_reference(name_one)
+        is_bare_definition = self._is_bare_definition_reference(name_one)
+        if is_bare_definition or (
+            is_home and self._chained_definition_call(name_one) is not None
+        ):
+            if reference.name_three is not None:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 does not yet support combining "
+                    "':definition()' with name_three during '*' traversal "
+                    "-- definition.json is not versioned, there is no "
+                    "version to select."
+                )
+            names = self.csvpaths.file_manager.named_file_names
+            if is_home:
+                names = [
+                    name for name in names if self._candidates_for_name(name, [])
+                ]
+            results = []
+            for name in names:
+                home = self.csvpaths.file_manager.named_file_home(name)
+                path = Nos(home).join("definition.json")
+                results.append(ReferenceResult3(path=path, uuid=None))
+            return ReferenceResults3(
+                results=results,
+                # Rule 1 (manifest_field_functions_proposal.md): resolving
+                # full METADATA_FILE content for more than one entity at
+                # once is illegal -- more than one named-file's own
+                # definition.json is exactly that case, same as :manifest()
+                # already flags via has_manifest/len(selected_candidates)
+                # below. query() itself still returns every match; only
+                # resolve_from() raises if a caller actually tries to
+                # resolve more than one of these at once.
+                ambiguous_content_read=len(results) > 1,
+            )
+
         is_grouped = self._is_bare_all_reference(name_one)
         is_flattened = self._is_bare_flatten_reference(name_one)
         is_deep_grouped = self._is_bare_groups_reference(name_one)
@@ -570,6 +633,28 @@ class FilesReferenceFinder3(ReferenceFinder3):
             candidates = []
             for name in self.csvpaths.file_manager.named_file_names:
                 candidates.extend(self._all_candidates_for_name(name))
+        elif is_home:
+            # bare ':home()', nothing chained onto it -- the zero-level
+            # ("no template") placeholder, exactly like the literal-root
+            # case's own is_bare_home_reference branch in query(), just
+            # gathered across every named-file instead of one. Not
+            # partitioned: an empty pattern is still a POOL-mode narrowing
+            # (one level, just zero segments), the same peer relationship
+            # a literal/'*' pattern already has to '*' traversal's own
+            # bare-path POOL mode above -- a terminal pointer picks one
+            # overall winner by time across every named-file's zero-level
+            # version, it does not pick one winner per named-file (that
+            # is what ':all()' is for).
+            if name_one.functions:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3 does not yet support chaining "
+                    f":{name_one.functions[0].name}() onto ':home()' "
+                    "during '*' traversal -- only ':definition()' is "
+                    "supported so far."
+                )
+            candidates = []
+            for name in self.csvpaths.file_manager.named_file_names:
+                candidates.extend(self._candidates_for_name(name, []))
         else:
             if name_one.functions:
                 raise ReferenceException3(
@@ -746,6 +831,56 @@ class FilesReferenceFinder3(ReferenceFinder3):
         )
 
     @staticmethod
+    def _is_home_prefixed_reference(name_one) -> bool:
+        """true when name_one's path is exactly a single, argument-less
+        ':home()' call -- UNLIKE _is_bare_home_reference, this does NOT
+        also require name_one.functions to be empty, since ':home()' is
+        legal here either bare (the zero-level placeholder, see
+        _query_star_traversal's own is_home branch) or with exactly one
+        ':definition()' chained onto it (the filtered-definition-lookup
+        shape, see _chained_definition_call) -- '*' traversal only,
+        added 2026-08-27 alongside that pair of shapes."""
+        return (
+            len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "home"
+            and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _is_bare_definition_reference(name_one) -> bool:
+        """true when name_one's entire content is a single, argument-
+        less ':definition()' call, with no trailing function chain --
+        the '*'-traversal counterpart to _is_bare_pointer_reference's
+        identical literal-root check (added 2026-08-27, see
+        _query_star_traversal's own early METADATA_FILE branch)."""
+        return (
+            not name_one.functions
+            and len(name_one.path) == 1
+            and isinstance(name_one.path[0], FunctionCall3)
+            and name_one.path[0].name == "definition"
+            and name_one.path[0].arg is None
+        )
+
+    @staticmethod
+    def _chained_definition_call(name_one) -> "FunctionCall3 | None":
+        """returns the ':definition()' FunctionCall3 when it is the ONE
+        thing chained onto name_one.functions (e.g. the "'home()':
+        ':definition()'" shape ':home():definition()'), else None. Added
+        2026-08-27 alongside _is_home_prefixed_reference -- the two are
+        meant to be checked together (is_home and this both non-None) to
+        recognize the filtered-definition-lookup shape specifically,
+        rather than any other function someone might try to chain onto
+        ':home()' during '*' traversal (still rejected, see the is_home
+        branch's own functions check)."""
+        if len(name_one.functions) != 1:
+            return None
+        call = name_one.functions[0]
+        if isinstance(call, FunctionCall3) and call.name == "definition" and call.arg is None:
+            return call
+        return None
+
+    @staticmethod
     def _is_bare_fingerprint_reference(name_one) -> bool:
         """same shape as _is_bare_home_reference, for ':fingerprint(...)'
         -- settled 2026-08-13, but the OPPOSITE arg requirement: WITH an
@@ -857,7 +992,20 @@ class FilesReferenceFinder3(ReferenceFinder3):
             ) or self._is_bare_pointer_reference(reference, "definition"):
                 # result.path is already the manifest.json/definition.json
                 # path itself (set by query()'s _query_well_known_file()
-                # branch above).
+                # branch above). Also covers bare ':definition()' during
+                # '*' traversal -- _is_bare_pointer_reference does not
+                # look at root_major, and _query_star_traversal's own
+                # early METADATA_FILE branch sets result.path the same
+                # way for that shape (added 2026-08-27).
+                return self._read_well_known_file(result.path)
+            if (
+                reference.name_three is None
+                and self._chained_definition_call(reference.name_one) is not None
+            ):
+                # ':home():definition()' chained during '*' traversal --
+                # added 2026-08-27. result.path is already the matched
+                # named-file's own definition.json path, set by
+                # _query_star_traversal's own early METADATA_FILE branch.
                 return self._read_well_known_file(result.path)
             if isinstance(reference.root_major, Star3) and result.uuid is not None:
                 # Rule 1b -- a pointer already reduced the global ledger

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -347,48 +347,33 @@ and a stale-entry correction, are both done — see
 ## `'*'` traversal — FILES, essentially untouched by the recent RESULTS/CSVPATHS work
 
 - `FilesReferenceFinder3`'s own `_query_star_traversal()` still rejects
-  combining `'*'` traversal with `:manifest()`/`:definition()`/a field-
-  accessor function outright — the same class of gap RESULTS/CSVPATHS
-  just had fixed (field accessors, then `:having()`/`:flatten()`/`:all()`,
-  then path narrowing/`name_three`, then pointer optionality), never
-  applied to FILES. FILES' traversal already never requires a pointer
-  (confirmed — no fix needed there), but everything else in that
-  generalization sequence hasn't been revisited for this datatype.
-  (`:definition()` added by name 2026-08-21 — previously only `:manifest()`
-  was called out here, but it has the identical gap, confirmed below.)
+  combining `'*'` traversal with `:manifest()`/a field-accessor function
+  outright (`:definition()` is now the one exception, see below) — the
+  same class of gap RESULTS/CSVPATHS just had fixed (field accessors,
+  then `:having()`/`:flatten()`/`:all()`, then path narrowing/`name_three`,
+  then pointer optionality), never applied to FILES otherwise. FILES'
+  traversal already never requires a pointer (confirmed — no fix needed
+  there), but everything else in that generalization sequence hasn't been
+  revisited for this datatype.
 
-- **Concrete worked example motivating this (David, 2026-08-21)**: "which
+- **Concrete worked example that drove this (David, 2026-08-21)**: "which
   named-files have `on_arrival` set" needs `$*.files.:home():definition
   (:on_arrival(:not_none()))` — every named-file, zero-level (no-template)
   registrations only, with `definition.json`'s `on_arrival` field present.
-  Live-tested each piece independently (dropping the not-yet-built
-  predicate, since it can't even parse) to confirm exactly what's missing,
-  rather than assuming one gap covers it — turns out this one reference
-  needs **four independent fixes**, not one:
-  1. Typo aside (`home()` needs its leading colon), `:home()` + `'*'`
-     traversal doesn't exist — `$*.files.:home()` alone raises `"Does not
-     yet support :home() as a name_one path segment."` `:home()`'s
-     zero-level-selector behavior (`_is_bare_home_reference`) was only ever
-     built for a literal root_major, never extended to traversal.
-  2. `:definition()` + `'*'` traversal doesn't exist either — same
-     rejection, confirmed independently. `:definition()` is only wired for
-     the literal-root bare case (`_is_bare_pointer_reference`); nothing
-     routes it through `_query_star_traversal` at all.
-  3. Chaining them together is *separately* blocked even once #1/#2 are
-     fixed — `$*.files.:home():definition()` raises a different, more
-     specific error: `"does not yet support functions attached directly to
-     name_one for '*' traversal."` A dedicated guard rejects any
-     function-in-name_one during `'*'` traversal, so fixing `:home()` and
-     `:definition()` individually would not automatically make the
-     combination work.
-  4. The predicate itself, `:on_arrival(:not_none())` — see the
-     predicate-argument entry above; not built anywhere, independent of
-     all three traversal issues above.
-
-  Use this reference as the acceptance test once all four pieces are
-  built: `$*.files.:home():definition(:on_arrival(:not_none()))` should
-  return exactly the zero-level named-files whose `definition.json` has a
-  non-`None` `on_arrival`.
+  Turned out to need four independent fixes, not one:
+  1. **`:home()` + `'*'` traversal — BUILT 2026-08-27**, see
+     `deferred_work_done_list.md`.
+  2. **`:definition()` + `'*'` traversal — BUILT 2026-08-27**, see
+     `deferred_work_done_list.md`.
+  3. **Chaining `:home():definition()` together — BUILT 2026-08-27**, see
+     `deferred_work_done_list.md`.
+  4. **The predicate itself, `:on_arrival(:not_none())` — still NOT
+     built.** See the predicate-argument entry above (the "any field
+     accessor takes a predicate argument" mechanism it needs is still
+     unbuilt). The full acceptance test
+     (`$*.files.:home():definition(:on_arrival(:not_none()))`) still
+     cannot parse until this lands — #1/#2/#3 were tested with the
+     predicate dropped, per the done-list entry's own worked examples.
 - FILES' `:all()`/`:groups()` (GROUP modes) combined with `:manifest()`/
   a field-accessor — same single-entity-vs-grouping restriction RESULTS'
   `name_three` content accessor now has, not yet built for FILES.

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,109 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `:home()`/`:definition()` during `'*'` traversal for FILES — three of four gaps BUILT 2026-08-27
+
+From the "FILES '*' traversal — essentially untouched by the recent
+RESULTS/CSVPATHS work" bucket-list entry, driven by David's concrete
+worked example (2026-08-21): "which named-files have `on_arrival` set"
+needs `$*.files.:home():definition(:on_arrival(:not_none()))`. Live
+testing had identified **four independent fixes** needed, not one; this
+pass builds the first three (the traversal/chaining machinery), leaving
+the fourth (a predicate argument, `:on_arrival(:not_none())`) to the
+separately-tracked predicate-argument entry — nothing about this build
+depends on that piece, and nothing here builds toward it either, they are
+genuinely independent.
+
+**Built, in `files_reference_finder_3.py`'s `_query_star_traversal()`:**
+
+1. **Bare `:home()` + `'*'` traversal.** `$*.files.:home()` used to raise
+   `"Does not yet support :home() as a name_one path segment"` (from
+   `_compile_path_pattern()`, which only recognizes `:name(...)`/clock
+   functions as legal path segments — `:home()`'s zero-level-selector
+   behavior was only ever wired for a literal root_major via
+   `_is_bare_home_reference`, never routed through `_query_star_traversal`
+   at all). Fixed by adding an `is_home` branch (new
+   `_is_home_prefixed_reference()` check) that gathers `_candidates_for_
+   name(name, [])` — the empty-pattern, zero-level match — across every
+   named-file, same as the existing is_grouped/is_flattened/is_deep_grouped
+   branches immediately above it in the same method. Deliberately NOT
+   partitioned by named-file (unlike `:all()`/`:groups()`): an empty
+   pattern is still a POOL-mode narrowing (one level, zero segments), the
+   same peer relationship a literal/`'*'` pattern already has to plain
+   `'*'` traversal's own bare-path POOL branch — a terminal pointer picks
+   ONE overall winner by time across every named-file's own zero-level
+   version, not one winner per named-file.
+
+2. **Bare `:definition()` + `'*'` traversal.** `$*.files.:definition()`
+   raised the identical "not a legal name_one path segment" error --
+   `:definition()` was only wired for the literal-root bare case
+   (`_is_bare_pointer_reference`), nothing routed it through
+   `_query_star_traversal`. Unlike `:manifest()` (which has Rule 1a's real
+   global ledger to fall back to at `"*"` root_major), `:definition()` has
+   no equivalent global resource -- so the traversal meaning built here is
+   "every named-file's own definition.json, one result per name," not a
+   single shared resource. New `_is_bare_definition_reference()` check,
+   early-returning (before the is_grouped/is_home/etc. dispatch) a
+   `ReferenceResult3` per `named_file_names` entry, path =
+   `named_file_home(name)/definition.json`, `uuid=None` (matches
+   `_query_well_known_file()`'s own convention for a non-versioned
+   resource). `ambiguous_content_read=True` whenever more than one result
+   comes back -- Rule 1 (`manifest_field_functions_proposal.md`) still
+   makes resolving full METADATA_FILE content for more than one entity at
+   once illegal; `query()` itself returns every match regardless (moved
+   2026-08-26, the `:path()`/Rule-1 relocation), only `resolve()`/
+   `resolve_from()` raises if a caller actually tries to read more than
+   one at once.
+
+3. **Chaining `:home():definition()` together.** Even with #1/#2 built
+   independently, `$*.files.:home():definition()` hit a *third*, separate
+   rejection: `"does not yet support functions attached directly to
+   name_one for '*' traversal"` -- a dedicated guard unconditionally
+   rejects any function chained onto name_one during `'*'` traversal, so
+   fixing `:home()`/`:definition()` individually did not make the
+   combination work. New `_chained_definition_call()` check (only
+   recognizes exactly one, argument-less `:definition()` chained onto a
+   bare `:home()` -- `_is_home_prefixed_reference()`, unlike
+   `_is_bare_home_reference()`, deliberately does NOT require
+   `name_one.functions` to be empty, so it matches both the bare and the
+   chained shape) folded into the same early-return branch as #2, but
+   FILTERED to only named-files with at least one zero-level candidate
+   (`_candidates_for_name(name, [])` non-empty) -- `:home()` here is a
+   FILTER ("only named-files with a plain, non-templated registration"),
+   not the placeholder-value role it plays bare; it has nothing to be a
+   placeholder FOR, since `:definition()` doesn't vary by
+   version/path the way a pointer's target would. Chaining anything OTHER
+   than `:definition()` onto `:home()` during `'*'` traversal still
+   raises, same as before.
+
+**`_extract_data()` changes:** bare `:definition()` during `'*'`
+traversal needed no new code at all -- `_is_bare_pointer_reference()`
+never checked `root_major`, so the existing literal-root branch
+(`return self._read_well_known_file(result.path)`) already fires
+correctly once `query()` sets `result.path` to the right definition.json.
+The chained `:home():definition()` shape needed one new branch (checks
+`_chained_definition_call()` directly) since `_is_bare_pointer_reference()`
+requires `name_one.functions` to be empty, which the chained shape never
+satisfies.
+
+**Deliberately scoped out of this pass, staying on the bucket list:**
+FILES' `:all()`/`:groups()` GROUP modes combined with `:manifest()`/a
+field-accessor (the same single-entity-vs-grouping restriction RESULTS'
+`name_three` content accessor already has); a literal prefix before
+`:flatten()`; `:from()`/`:to()` combined with `:all()`/`:groups()`
+grouping; a literal name_three body. None of these were touched or made
+easier/harder by this pass -- see the bucket list's own updated entry.
+
+Tests: new `TestStarTraversalHome`/`TestStarTraversalDefinition` classes
+in `tests/references/test_files_reference_finder_3.py` (query shape,
+zero-level filtering, `ambiguous_content_read`, name_three rejection,
+resolve-reads-real-bytes-per-named-file); the stale
+`test_star_with_definition_is_still_not_supported` (which asserted the
+OLD, now-wrong "always raises" behavior) was replaced with a comment
+pointing at the new coverage. Full local-backend suite green (3036/3036,
+run twice) plus the 11 known SFTP/S3 env-dependent failures (issue #216
+et al., unrelated to this change).
+
 ## `:name(/regex/)` — a name_one path segment can now be a regex — BUILT 2026-08-27
 
 From the "grammar / argument-type gaps" bucket-list entry: `Name3.

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -463,17 +463,17 @@ class TestGlobalArrivalsLedger:
         results = finder.resolve()
         assert results.results[0].data == content
 
-    def test_star_with_definition_is_still_not_supported(self):
-        # :definition() has no equivalent global resource anywhere in
-        # the codebase -- stays unsupported at "*" root_major.
-        finder = _finder(
-            "$*.files.:definition()",
-            ALPHA_HOME,
-            ALPHA_MANIFEST,
-            inputs_files_path="inputs/named_files",
-        )
-        with pytest.raises(ReferenceException3):
-            finder.query()
+    # :manifest() alone stays the one function with a real GLOBAL
+    # resource to fall back to at "*" root_major (Rule 1a, above) --
+    # :definition() has no such global resource, so a bare ':definition()'
+    # at "*" root_major means something different: every named-file's own
+    # definition.json, one per name. See TestStarTraversalDefinition
+    # below (added 2026-08-27, FILES '*' traversal generalization
+    # bucket-list entry) -- this used to be unsupported outright, since
+    # nothing routed :definition() through _query_star_traversal() at
+    # all; a fixture with only one named-file (ALPHA_HOME/ALPHA_MANIFEST,
+    # by_name=None means named_file_names is []) could not have exercised
+    # the real "*" case anyway.
 
 LEDGER = [
     {"named_file_name": "alpha", "uuid": "u-ledger-1"},
@@ -775,6 +775,159 @@ class TestStarTraversalGroupsAnyDepth:
     def test_combining_with_manifest_is_not_yet_supported(self):
         with pytest.raises(ReferenceException3):
             _flatten_star_finder("$*.files.:groups().:last():manifest()").query()
+
+
+#
+# alpha has TWO zero-level ("no template") entries directly at its own
+# home; beta has only a ONE-level "orders.csv" entry -- proves ':home()'
+# traversal pools zero-level candidates ACROSS named-files (not just
+# within one, which TestHomeAsAZeroLevelSelector already covers), and
+# that a named-file with no zero-level registration at all is correctly
+# excluded/contributes nothing -- both to the plain pooled-candidate
+# shape and to the ':home():definition()' filtered-lookup shape below.
+#
+HOME_STAR_ALPHA_HOME = "inputs/named_files/alpha"
+HOME_STAR_ALPHA_MANIFEST = [
+    {
+        "file": "inputs/named_files/alpha/aaa.csv",
+        "file_home": "inputs/named_files/alpha",
+        "uuid": "u-alpha-zero-1",
+        "time": "2026-01-01T00:00:00+00:00",
+    },
+    {
+        "file": "inputs/named_files/alpha/bbb.csv",
+        "file_home": "inputs/named_files/alpha",
+        "uuid": "u-alpha-zero-2",
+        "time": "2026-01-03T00:00:00+00:00",
+    },
+]
+HOME_STAR_BETA_HOME = "inputs/named_files/beta"
+HOME_STAR_BETA_MANIFEST = [
+    {
+        "file": "inputs/named_files/beta/orders.csv/ccc.csv",
+        "file_home": "inputs/named_files/beta/orders.csv",
+        "uuid": "u-beta-one-level",
+        "time": "2026-01-02T00:00:00+00:00",
+    },
+]
+HOME_STAR_BY_NAME = {
+    "alpha": (HOME_STAR_ALPHA_HOME, HOME_STAR_ALPHA_MANIFEST),
+    "beta": (HOME_STAR_BETA_HOME, HOME_STAR_BETA_MANIFEST),
+}
+
+
+def _home_star_finder(reference: str) -> FilesReferenceFinder3:
+    return _finder(
+        reference, HOME_STAR_ALPHA_HOME, HOME_STAR_ALPHA_MANIFEST, by_name=HOME_STAR_BY_NAME
+    )
+
+
+class TestStarTraversalHome:
+    # bare ':home()' as name_one's entire content during '*' traversal --
+    # added 2026-08-27 (FILES '*' traversal generalization bucket-list
+    # entry, gap #1: ":home()" + "'*'" traversal did not exist at all,
+    # raising "Does not yet support :home() as a name_one path segment").
+    # Not partitioned (mirrors the plain-path POOL branch immediately
+    # above, just with an empty pattern instead of a compiled one) -- a
+    # terminal pointer picks ONE overall winner by time across every
+    # named-file's own zero-level candidates, it does not pick one winner
+    # per named-file (':all()' already does that).
+    def test_last_pools_zero_level_candidates_across_named_files(self):
+        results = _home_star_finder("$*.files.:home().:last()").query()
+        assert results.uuids == ["u-alpha-zero-2"]
+
+    def test_a_named_file_with_no_zero_level_entry_contributes_nothing(self):
+        # beta's only entry is one level deep -- must never appear,
+        # regardless of pointer.
+        results = _home_star_finder("$*.files.:home().:first()").query()
+        assert "u-beta-one-level" not in results.uuids
+        assert results.uuids == ["u-alpha-zero-1"]
+
+    def test_with_no_name_three_dedupes_to_zero_level_file_homes_only(self):
+        results = _home_star_finder("$*.files.:home()").query()
+        assert results.files == [HOME_STAR_ALPHA_HOME]
+
+    def test_chaining_anything_other_than_definition_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _home_star_finder("$*.files.:home():uuid().:last()").query()
+
+
+class TestStarTraversalDefinition:
+    # bare ':definition()' during '*' traversal (gap #2) and ':home()'
+    # with ':definition()' chained onto it (gap #3, "does not yet support
+    # functions attached directly to name_one for '*' traversal" even
+    # once #1/#2 individually work) -- both added 2026-08-27, same
+    # bucket-list entry as TestStarTraversalHome above. Neither takes
+    # name_three -- definition.json is never versioned, so there is
+    # nothing left to narrow once a named-file is matched.
+    def test_bare_definition_gives_one_result_per_named_file(self):
+        results = _home_star_finder("$*.files.:definition()").query()
+        assert set(results.files) == {
+            f"{HOME_STAR_ALPHA_HOME}/definition.json",
+            f"{HOME_STAR_BETA_HOME}/definition.json",
+        }
+        assert all(r.uuid is None for r in results.results)
+
+    def test_bare_definition_flags_ambiguous_content_read_when_plural(self):
+        # Rule 1 (manifest_field_functions_proposal.md): resolving full
+        # METADATA_FILE content for more than one entity at once is
+        # illegal -- more than one named-file's own definition.json is
+        # exactly that case, same as :manifest() already flags.
+        results = _home_star_finder("$*.files.:definition()").query()
+        assert results.ambiguous_content_read is True
+
+    def test_home_prefixed_definition_filters_to_zero_level_named_files_only(self):
+        # beta has no zero-level registration -- must be excluded, even
+        # though it has its own definition.json like any named-file would.
+        results = _home_star_finder("$*.files.:home():definition()").query()
+        assert results.files == [f"{HOME_STAR_ALPHA_HOME}/definition.json"]
+        assert results.ambiguous_content_read is False
+
+    def test_bare_definition_combined_with_name_three_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _home_star_finder("$*.files.:definition().:last()").query()
+
+    def test_home_prefixed_definition_combined_with_name_three_is_not_yet_supported(
+        self,
+    ):
+        with pytest.raises(ReferenceException3):
+            _home_star_finder("$*.files.:home():definition().:last()").query()
+
+    def test_resolve_reads_each_named_files_own_definition_bytes(self, tmp_path):
+        # manifest file_home values must actually match the tmp_path
+        # homes below (unlike HOME_STAR_ALPHA_MANIFEST's hardcoded
+        # "inputs/named_files/..." strings) -- ':home()' filters by real
+        # file_home-vs-home matching, not by name alone.
+        alpha_home = tmp_path / "alpha"
+        alpha_home.mkdir()
+        (alpha_home / "definition.json").write_bytes(b'{"on_arrival": "go"}')
+        alpha_manifest = [
+            {
+                "file": str(alpha_home / "aaa.csv"),
+                "file_home": str(alpha_home),
+                "uuid": "u-alpha-zero-1",
+            }
+        ]
+        beta_home = tmp_path / "beta"
+        beta_home.mkdir()
+        (beta_home / "definition.json").write_bytes(b'{"on_arrival": null}')
+        beta_manifest = [
+            {
+                "file": str(beta_home / "orders.csv" / "ccc.csv"),
+                "file_home": str(beta_home / "orders.csv"),
+                "uuid": "u-beta-one-level",
+            }
+        ]
+        by_name = {
+            "alpha": (str(alpha_home), alpha_manifest),
+            "beta": (str(beta_home), beta_manifest),
+        }
+        finder = _finder(
+            "$*.files.:home():definition()", str(alpha_home), [], by_name=by_name
+        )
+        results = finder.resolve()
+        assert len(results.results) == 1
+        assert results.results[0].data == b'{"on_arrival": "go"}'
 
 
 class TestAllForOneNamedFile:


### PR DESCRIPTION
## Summary

Closes three of the four gaps identified in the deferred-work bucket list "FILES star traversal" entry (David, 2026-08-21), driven by the worked example "which named-files have on_arrival set":

    $*.files.:home():definition(:on_arrival(:not_none()))

- **Bare `:home()` + star traversal.** Used to raise "Does not yet support :home() as a name_one path segment". Now pools every named-file own zero-level (no-template) candidates into one POOL, the same peer relationship a literal/star pattern already has to plain star traversal (not partitioned per named-file -- a terminal pointer picks one overall winner by time, across every named-file zero-level version).
- **Bare `:definition()` + star traversal.** Was only wired for the literal-root bare case. Now returns one result per named-file, its own definition.json -- unlike `:manifest()`, there is no equivalent global ledger to fall back to (Rule 1a), so this means "every named-file own config," not one shared resource. Flags `ambiguous_content_read` when plural, matching Rule 1 (`manifest_field_functions_proposal.md`).
- **Chaining `:home():definition()` together.** A separate guard rejected any function chained onto name_one during star traversal, even once the two pieces above worked independently. Now recognized as its own shape: filters to only named-files with a zero-level registration, then reads each one own definition.json -- `:home()` acts as a FILTER here, not the placeholder-value role it plays bare.

**Deliberately not built here:** the fourth gap, a predicate argument (`:on_arrival(:not_none())`), is a separate, already-tracked mechanism (the generic "any field accessor takes a predicate argument" design) -- not needed by this change and not attempted. The full acceptance test from the bucket list still cannot parse until that lands.

## Design notes

- New `_is_home_prefixed_reference()` deliberately does NOT require `name_one.functions` to be empty (unlike the existing `_is_bare_home_reference()`, used by the literal-root case) -- it needs to match both the bare and the `:definition()`-chained shape.
- `_extract_data()` needed no change at all for bare `:definition()` during star traversal -- `_is_bare_pointer_reference()` never checked `root_major`, so the existing literal-root branch already fires correctly once `query()` sets `result.path`. The chained shape needed one new branch, since that check requires `name_one.functions` to be empty.
- Literal-root `:home():definition()` chaining is untouched/still unsupported -- out of scope, not part of the driving worked example (which is star-traversal-specific), and arguably redundant there anyway (no traversal ambiguity to filter in the first place).
- Bucket list / done list updated: the 3 built pieces moved to `deferred_work_done_list.md` with full reasoning; the still-open predicate piece and the other FILES-star-traversal gaps (GROUP-mode + manifest/field-accessor, literal-prefix-before-flatten, from/to grouping, literal name_three body) stay on the bucket list, untouched by this pass.
- `references_v3_compendium.md` intentionally not touched -- David is mid-edit on that file directly on `compendium_scrub_2`.

## Test plan

- [x] New `TestStarTraversalHome`/`TestStarTraversalDefinition` classes in `tests/references/test_files_reference_finder_3.py` -- query shape, zero-level filtering, `ambiguous_content_read`, name_three rejection, resolve-reads-real-bytes-per-named-file (via `tmp_path`).
- [x] Stale `test_star_with_definition_is_still_not_supported` (asserted the old "always raises" behavior for `$*.files.:definition()`) replaced with a comment pointing at the new coverage.
- [x] `tests/references/` + `tests/csvpaths/references/`: 1484 passed.
- [x] Full local-backend suite: 3036/3036 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
