### PR TITLE
Add named_paths_fingerprint to the Results Run Manifest

### DIFF
--- a/csvpath/managers/integrations/otlp/otlp_results_listener.py
+++ b/csvpath/managers/integrations/otlp/otlp_results_listener.py
@@ -60,4 +60,6 @@ class OpenTelemetryResultsListener(OtlpListener):
             cmeta["time_completed"] = mdata.time_completed_string
         if mdata.named_paths_uuid_string:
             cmeta["named_paths_uuid_string"] = mdata.named_paths_uuid_string
+        if mdata.named_paths_fingerprint:
+            cmeta["named_paths_fingerprint"] = mdata.named_paths_fingerprint
         return cmeta

--- a/csvpath/managers/paths/paths_manager.py
+++ b/csvpath/managers/paths/paths_manager.py
@@ -156,6 +156,39 @@ class PathsManager:
                 return m[len(m) - 1]["uuid"]
         raise ValueError(f"No manifest for path named {name}")
 
+    def get_fingerprint_for_name(self, name: NamedPathsName) -> str:
+        """@private -- the most recently registered version's own
+        content fingerprint for named-paths group `name` (the group's
+        own group.csvpaths text, not any run's copy of it) -- mirrors
+        get_named_paths_uuid's own name/reference resolution exactly,
+        just returning "fingerprint" instead of "uuid" off the same last
+        manifest entry. Used by ResultsRegistrar to record which
+        named-paths CONTENT drove a run (Results Run Manifest's own
+        named_paths_fingerprint field), distinct from named_paths_uuid,
+        which only records the group version's registration identity --
+        two groups loaded from identical group.csvpaths text under
+        different names get different uuids but identical fingerprints."""
+        if name is None:
+            raise ValueError("Paths name cannot be None")
+        if name.find("#") > -1:
+            name = name[0 : name.find("#")]
+        if name.startswith("$"):
+            ref = ReferenceParser(name, csvpaths=self.csvpaths)
+            if ref.datatype != ReferenceParser.CSVPATHS:
+                raise ValueError(
+                    "Must be a reference of type {ReferenceParser.CSVPATHS}"
+                )
+            name = ref.root_major
+
+        path = self.named_paths_home(name)
+        path = Nos(path).join("manifest.json")
+        nos = Nos(path)
+        if nos.exists():
+            with DataFileReader(path) as reader:
+                m = json.load(reader.source)
+                return m[len(m) - 1]["fingerprint"]
+        raise ValueError(f"No manifest for path named {name}")
+
     @property
     def named_paths_dir(self) -> str:
         """@private"""

--- a/csvpath/managers/results/results_metadata.py
+++ b/csvpath/managers/results/results_metadata.py
@@ -12,6 +12,16 @@ class ResultsMetadata(Metadata):
         self.run_home: str = None
         self.named_paths_name: str = None
         self.named_paths_uuid: UUID = None
+        #
+        # the content fingerprint of the named-paths group version that
+        # drove this run (as opposed to named_paths_uuid, its
+        # registration identity) -- lets a run be compared, by content,
+        # against the group that produced it, catching the case where
+        # the same group.csvpaths text was loaded under two different
+        # names (different uuids, identical fingerprints). See
+        # NamedPathsFingerprint3.
+        #
+        self.named_paths_fingerprint: str = None
         self.named_results_name: str = None
         self.named_file_uuid: str = None
         self.named_file_name: str = None
@@ -119,6 +129,7 @@ class ResultsMetadata(Metadata):
         self.run_uuid_string = m.get("run_uuid")
         self.named_paths_name = m.get("named_paths_name")
         self.named_paths_uuid_string = m.get("named_paths_uuid")
+        self.named_paths_fingerprint = m.get("named_paths_fingerprint")
         self.named_file_name = m.get("named_file_name")
         self.named_file_uuid_string = m.get("named_file_uuid")
         self.named_file_path = m.get("named_file_path")

--- a/csvpath/managers/results/results_registrar.py
+++ b/csvpath/managers/results/results_registrar.py
@@ -45,6 +45,9 @@ class ResultsRegistrar(Registrar, Listener):
         mdata.named_file_path = filepath
         mdata.named_file_size = self._size(filepath)
         mdata.named_file_last_change = self._last_change(filepath)
+        mdata.named_paths_fingerprint = self.csvpaths.paths_manager.get_fingerprint_for_name(
+            self.pathsname
+        )
         self.distribute_update(mdata)
         # after we distribute the update
         # if we see a fingerprint mismatch we need to log it
@@ -106,6 +109,7 @@ class ResultsRegistrar(Registrar, Listener):
         #
         m["named_paths_name"] = mdata.named_paths_name
         m["named_paths_uuid"] = mdata.named_paths_uuid_string
+        m["named_paths_fingerprint"] = mdata.named_paths_fingerprint
         #
         m["named_file_name"] = mdata.named_file_name
         m["named_file_uuid"] = mdata.named_file_uuid_string

--- a/csvpath/references/functions/fields/named_paths_fingerprint_3.py
+++ b/csvpath/references/functions/fields/named_paths_fingerprint_3.py
@@ -1,0 +1,35 @@
+from ...reference_3 import Reference3
+from ..function_3 import Function3
+
+
+class NamedPathsFingerprint3(Function3):
+    #
+    # Results Run Manifest (table 5)'s own "named_paths_fingerprint" --
+    # the fingerprint of the named-paths group version whose content
+    # drove this run. A different ENTITY's content than Fingerprint3/
+    # :fingerprint() (the FILES/CSVPATHS entity's own content
+    # fingerprint) describes, but the same conceptual KIND -- see
+    # fingerprint_3.py's own note on why these are grouped for UNION
+    # comparison purposes (byte-identity) despite belonging to
+    # different entities. Lets a run be compared, by content (not
+    # registration event), against the named-paths group that produced
+    # it -- catching the case where the same group.csvpaths text was
+    # loaded under two different names (different uuids, identical
+    # fingerprints), something named_paths_uuid/:named_paths_uuid()
+    # cannot do.
+    #
+    NAME = "named_paths_fingerprint"
+    SUMMARY = (
+        "The fingerprint of the named-paths group version whose content "
+        "drove the resolved run."
+    )
+    ROLE = Function3.VALUE
+    DATATYPES = (Reference3.RESULTS,)
+    ARG_TYPES = ()
+    ARG_REQUIRED = False
+    SOURCE = "manifest"
+    KIND = "fingerprint"
+    KEY = {
+        Reference3.RESULTS: "named_paths_fingerprint",
+    }
+    POSITIONS = {Reference3.RESULTS: (Reference3.NAME_ONE,)}

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -89,6 +89,7 @@ class ReferenceFunctionFactory:
         from .fields.named_files_root_3 import NamedFilesRoot3
         from .fields.named_paths_3 import NamedPaths3
         from .fields.named_paths_count_3 import NamedPathsCount3
+        from .fields.named_paths_fingerprint_3 import NamedPathsFingerprint3
         from .fields.named_paths_group_3 import NamedPathsGroup3
         from .fields.named_paths_identities_3 import NamedPathsIdentities3
         from .fields.named_paths_name_3 import NamedPathsName3
@@ -260,6 +261,7 @@ class ReferenceFunctionFactory:
             NamedFileSize3.NAME: NamedFileSize3,
             NamedFileLastChange3.NAME: NamedFileLastChange3,
             NamedFileFingerprint3.NAME: NamedFileFingerprint3,
+            NamedPathsFingerprint3.NAME: NamedPathsFingerprint3,
             RunDir3.NAME: RunDir3,
             InstanceIndex3.NAME: InstanceIndex3,
             NamedPathsGroup3.NAME: NamedPathsGroup3,

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -411,6 +411,7 @@ _METADATA_FIELD_FUNCTIONS = (
     "named_file_size",
     "named_file_last_change",
     "named_file_fingerprint",
+    "named_paths_fingerprint",
     "run_dir",
     "instance_index",
     "named_paths_group",

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -9,23 +9,6 @@ instead, so the completed reasoning trail isn't lost, it's just off this
 list (see that file's own header, and the "Process note" at the bottom of
 this one).
 
-## Results Run Manifest has no `named_paths_fingerprint` field
-
-Surfaced by David, 2026-08-26, while correcting the UNION `KIND`
-taxonomy (see `deferred_work_done_list.md`'s "UNION compatibility
-revised again... to compare by conceptual `KIND`" entry): the Results
-Run Manifest (table 5) records `named_file_fingerprint` (which named-
-file content drove the run) but has no equivalent field for which
-named-paths group *content* drove the run — only `named_paths_uuid`
-(the group version's registration identity, not its content). David's
-own words: "it's not, but should be." This is what would let a run be
-compared, by `:fingerprint()`/`KIND == "fingerprint"`, against the
-named-paths group whose *content* (not registration event) produced it
--- catching the case where the same `group.csvpath` text was loaded
-under two different names (different uuids, identical fingerprint).
-Not yet built: no `NamedPathsFingerprint3` function, no manifest field,
-no registrar change to populate it.
-
 ## `'*'`-traversal content-accessor guards — candidates for the same query()/resolve() split, not yet re-audited
 
 Left over from retiring `:path()`/moving Rule 1 to `resolve()` (see

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,94 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## Results Run Manifest `named_paths_fingerprint` field — BUILT 2026-08-27 (closes issue #262)
+
+Surfaced by David, 2026-08-26, while correcting the UNION `KIND`
+taxonomy (see this file's own "UNION compatibility revised again... to
+compare by conceptual `KIND`" entry below): the Results Run Manifest
+(table 5) records `named_file_fingerprint` (which named-file content
+drove the run) but had no equivalent field for which named-paths group
+*content* drove the run — only `named_paths_uuid` (the group version's
+registration identity, not its content). David's own words: "it's not,
+but should be." This is what lets a run be compared, by
+`:fingerprint()`/`KIND == "fingerprint"`, against the named-paths group
+whose *content* (not registration event) produced it -- catching the
+case where the same `group.csvpaths` text was loaded under two
+different names (different uuids, identical fingerprint). Also filed
+as GitHub issue #262.
+
+**Built, mirroring `named_file_fingerprint`'s own shape exactly (same
+manifest, same UNION `KIND`, same field-accessor pattern) end to end:**
+
+- **`PathsManager.get_fingerprint_for_name(name)`** (`paths_manager.py`)
+  -- new method, deliberately copy-shaped after the existing
+  `get_named_paths_uuid(name)` right above it (same `None`/`"#"`-
+  fragment/`"$"`-reference handling, same manifest-read-and-raise-if-
+  missing shape), just returning the last manifest entry's own
+  `"fingerprint"` key instead of `"uuid"`. Not factored into a shared
+  helper with `get_named_paths_uuid` -- the two methods are already
+  small and independently readable; extracting a helper for two
+  one-line-different call sites would be the premature-abstraction
+  CLAUDE.md style guidance warns against, not a real simplification.
+- **`ResultsMetadata.named_paths_fingerprint`** (`results_metadata.py`)
+  -- new attribute (plain `str`, unlike `named_paths_uuid`'s `UUID`
+  typing/property pair -- a fingerprint is just an opaque hash string,
+  same as `named_file_fingerprint`'s own plain-`str` treatment), wired
+  into `from_manifest()` alongside `named_paths_uuid_string`.
+- **`ResultsRegistrar.register_start()`/`metadata_update()`**
+  (`results_registrar.py`) -- populates
+  `mdata.named_paths_fingerprint` via
+  `self.csvpaths.paths_manager.get_fingerprint_for_name(self.pathsname)`,
+  right alongside the existing named-file fingerprint fetch (same
+  method, same registrar, same call shape); writes it into the run
+  manifest dict as `"named_paths_fingerprint"`, right alongside
+  `"named_paths_uuid"`.
+- **`NamedPathsFingerprint3`** (new `Function3` subclass,
+  `named_paths_fingerprint_3.py`) -- `RESULTS`-only field accessor,
+  `SOURCE = "manifest"`, `KIND = "fingerprint"` (the same `KIND` as
+  `Fingerprint3`/`NamedFileFingerprint3` -- byte-identity is meaningful
+  across different entities, per `Fingerprint3`'s own already-settled
+  2026-08-26 KIND-taxonomy note), `KEY = {RESULTS: "named_paths_fingerprint"}`.
+  Registered in `reference_function_factory_3.py`; `"named_paths_fingerprint"`
+  added to `reference_3.py`'s `_METADATA_FIELD_FUNCTIONS` tuple. No
+  finder-specific code needed anywhere -- field accessors resolve
+  generically off `SOURCE`/`KEY`, and UNION `KIND` comparison
+  (`reference_expression_3.py`) reads `Function3.KIND` declaratively
+  off the registered class, so declaring `KIND = "fingerprint"` was
+  the only wiring `ReferenceExpression3` needed.
+
+**Deliberately scoped out, on request (David, 2026-08-27, asked
+directly rather than assumed):** the SQLite (`sqlite_results_listener.py`)
+and SQL (`sql_results_listener.py`/`tables.py`) integrations already
+mirror `named_file_fingerprint` into their own DB schemas, but wiring
+`named_paths_fingerprint` into those too would need real schema/DDL
+changes (`Sqliter`'s schema.sql, a new SQLAlchemy `Column`) -- beyond
+what the original bucket-list ask actually specified (function +
+manifest field + registrar change, not the downstream DB integrations).
+Left untouched; the field is still fully usable via
+`:named_paths_fingerprint()` and directly in `manifest.json`. The OTLP
+integration (`otlp_results_listener.py`) WAS wired in -- a single
+additive dict key in an existing `core_meta()` override, no schema
+involved, so no scope-expansion risk.
+
+Tests: new `test_named_paths_fingerprint_3.py` (Function3 metadata/
+arg-validation, mirrors `test_named_file_fingerprint_3.py`); new
+`PathsManager.get_fingerprint_for_name` coverage in
+`test_csvpaths_managers_paths_manager.py` (happy path against a real
+`add_named_paths`-registered group, `None`-name raise, no-manifest
+raise); new `ResultsMetadata` coverage in
+`test_csvpaths_managers_results_metadata.py` (`from_manifest` reads
+the field, defaults to `None`); extended
+`test_results_reference_finder_3.py`'s existing
+`test_run_scope_fields_added_2026_08_25` with the new field; extended
+`test_reference_expression_3.py`'s `orders_archive` fixture with a
+`named_paths_fingerprint` value and added
+`test_union_of_fingerprint_and_named_paths_fingerprint_succeeds` --
+the actual originally-motivating end-to-end case (`$groupa.csvpaths.
+:fingerprint()` UNION `$groupa.results.:flatten():named_paths_fingerprint()`).
+Full local-backend suite green (3045/3045, run twice); pre-existing
+SFTP/S3 env-dependent failures unrelated to this change.
+
 ## `:home()`/`:definition()` during `'*'` traversal for FILES — three of four gaps BUILT 2026-08-27
 
 From the "FILES '*' traversal — essentially untouched by the recent

--- a/tests/csvpaths/managers/test_csvpaths_managers_paths_manager.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_paths_manager.py
@@ -227,6 +227,30 @@ class TestCsvPathsManagersPathsManager(unittest.TestCase):
         lst = CsvPaths().paths_manager.get_named_paths(name)
         assert lst is None
 
+    def test_get_fingerprint_for_name(self):
+        # get_fingerprint_for_name mirrors get_named_paths_uuid exactly,
+        # just returning the last manifest entry's own "fingerprint"
+        # instead of "uuid" -- added 2026-08-27 for the Results Run
+        # Manifest's own named_paths_fingerprint field (see
+        # ResultsRegistrar.register_start).
+        name = f"{uuid4()}"
+        apath = "$[*][yes()]"
+        paths = Builder().build()
+        paths.paths_manager.add_named_paths(name=name, paths=[apath])
+        fingerprint = CsvPaths().paths_manager.get_fingerprint_for_name(name)
+        assert fingerprint
+        mani = CsvPaths().paths_manager.get_manifest_for_name(name)
+        assert fingerprint == mani[-1]["fingerprint"]
+        CsvPaths().paths_manager.remove_named_paths(name)
+
+    def test_get_fingerprint_for_name_none_raises(self):
+        with self.assertRaises(ValueError):
+            CsvPaths().paths_manager.get_fingerprint_for_name(None)
+
+    def test_get_fingerprint_for_name_no_manifest_raises(self):
+        with self.assertRaises(ValueError):
+            CsvPaths().paths_manager.get_fingerprint_for_name(f"{uuid4()}")
+
     def test_named_paths_adda(self):
         name = f"{uuid4()}"
         apath = "$[*][yes()]"

--- a/tests/csvpaths/managers/test_csvpaths_managers_results_metadata.py
+++ b/tests/csvpaths/managers/test_csvpaths_managers_results_metadata.py
@@ -35,3 +35,20 @@ class TestCsvPathsManagersResultsMetadata(unittest.TestCase):
         m.from_manifest(manifest)
         assert m.run_uuid_string == run_uuid
         assert m.uuid_string == run_uuid
+
+    def test_named_paths_fingerprint_defaults_to_none(self) -> None:
+        m = ResultsMetadata(None)
+        assert m.named_paths_fingerprint is None
+
+    def test_from_manifest_reads_named_paths_fingerprint(self) -> None:
+        m = ResultsMetadata(None)
+        manifest = {
+            "run_home": "some/run/home",
+            "uuid": str(uuid4()),
+            "run_uuid": str(uuid4()),
+            "named_paths_uuid": str(uuid4()),
+            "named_file_uuid": str(uuid4()),
+            "named_paths_fingerprint": "abc123",
+        }
+        m.from_manifest(manifest)
+        assert m.named_paths_fingerprint == "abc123"

--- a/tests/references/functions/fields/test_named_paths_fingerprint_3.py
+++ b/tests/references/functions/fields/test_named_paths_fingerprint_3.py
@@ -1,0 +1,27 @@
+import pytest
+
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.functions.fields.named_paths_fingerprint_3 import (
+    NamedPathsFingerprint3,
+)
+from csvpath.references.reference_3 import Reference3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = NamedPathsFingerprint3()
+    assert f.name == "named_paths_fingerprint"
+    assert f.ROLE == Function3.VALUE
+    assert f.DATATYPES == (Reference3.RESULTS,)
+    assert f.SOURCE == "manifest"
+    assert f.KIND == "fingerprint"
+    assert f.KEY == {Reference3.RESULTS: "named_paths_fingerprint"}
+
+
+def test_no_arg_is_valid():
+    NamedPathsFingerprint3().check_valid()  # should not raise
+
+
+def test_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        NamedPathsFingerprint3(arg="x").check_valid()

--- a/tests/references/test_reference_expression_3.py
+++ b/tests/references/test_reference_expression_3.py
@@ -402,12 +402,20 @@ def _write_json(path, data) -> None:
 
 
 def _make_run(
-    base, run_name: str, run_uuid: str, group_name: str, *, named_file_fingerprint=None
+    base,
+    run_name: str,
+    run_uuid: str,
+    group_name: str,
+    *,
+    named_file_fingerprint=None,
+    named_paths_fingerprint=None,
 ) -> str:
     run_dir = base / run_name
     manifest = {"run_uuid": run_uuid, "named_paths_name": group_name}
     if named_file_fingerprint is not None:
         manifest["named_file_fingerprint"] = named_file_fingerprint
+    if named_paths_fingerprint is not None:
+        manifest["named_paths_fingerprint"] = named_paths_fingerprint
     _write_json(run_dir / "manifest.json", manifest)
     return str(run_dir)
 
@@ -432,6 +440,7 @@ def orders_archive(tmp_path):
             "a1",
             "groupa",
             named_file_fingerprint="groupa-fp",
+            named_paths_fingerprint="groupa-fp",
         ),
         _make_run(archive / "groupa", "2026-01-02_00-00-00", "a2", "groupa"),
     ]
@@ -674,6 +683,31 @@ class TestPathsVsValuesEndToEnd:
             left="$groupa.csvpaths.:fingerprint()",  # values -- KIND "fingerprint"
             op=ReferenceExpression3.UNION,
             right="$groupa.results.:flatten():named_file_fingerprint()",  # values -- KIND "fingerprint"
+            csvpaths=orders_archive,
+        )
+        result = expr.resolve()
+        assert "groupa-fp" in {r.data for r in result.results}
+
+    def test_union_of_fingerprint_and_named_paths_fingerprint_succeeds(
+        self, orders_archive
+    ):
+        # the ORIGINAL motivating case for named_paths_fingerprint
+        # existing at all (bucket-list entry, David 2026-08-26/added
+        # 2026-08-27): "let a run be compared, by content, against the
+        # named-paths group whose content produced it -- catching the
+        # case where the same group.csvpaths text was loaded under two
+        # different names (different uuids, identical fingerprints)."
+        # :fingerprint() here reads groupa's CURRENT content fingerprint
+        # (GROUPA_MANIFEST's own "groupa-fp"); :named_paths_fingerprint()
+        # reads run a1's own RECORD of which content drove it -- set to
+        # the same value by the orders_archive fixture. Both share
+        # KIND == "fingerprint", same as the named_file_fingerprint
+        # pairing above, just for the named-paths entity instead of the
+        # named-file one.
+        expr = ReferenceExpression3(
+            left="$groupa.csvpaths.:fingerprint()",  # values -- KIND "fingerprint"
+            op=ReferenceExpression3.UNION,
+            right="$groupa.results.:flatten():named_paths_fingerprint()",  # values -- KIND "fingerprint"
             csvpaths=orders_archive,
         )
         result = expr.resolve()

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -1639,6 +1639,7 @@ class TestFieldAccessorFunctions:
                 "run_uuid": "run1-uuid",
                 "error_count": 3,
                 "named_paths_uuid": "paths-uuid-1",
+                "named_paths_fingerprint": "cafef00d",
                 "named_file_uuid": "file-uuid-1",
                 "named_file_path": "/inputs/named_files/widgets/data.csv",
                 "named_file_size": 1024,
@@ -1655,6 +1656,7 @@ class TestFieldAccessorFunctions:
 
         assert _val("error_count") == 3
         assert _val("named_paths_uuid") == "paths-uuid-1"
+        assert _val("named_paths_fingerprint") == "cafef00d"
         assert _val("named_file_uuid") == "file-uuid-1"
         assert _val("named_file_path") == "/inputs/named_files/widgets/data.csv"
         assert _val("named_file_size") == 1024


### PR DESCRIPTION
## Summary

Closes #262 and a deferred-work bucket-list item (David, 2026-08-26): the Results Run Manifest (table 5) recorded `named_file_fingerprint` (which named-file content drove the run) but had no equivalent for which named-paths group *content* drove it -- only `named_paths_uuid`, a registration identity, not content. This is what lets a run be compared, by `:fingerprint()`/`KIND == "fingerprint"`, against the named-paths group whose content (not registration event) produced it -- catching the case where the same `group.csvpaths` text was loaded under two different names (different uuids, identical fingerprints).

## What was built

Mirrors `named_file_fingerprint`'s own shape exactly, end to end:

- **`PathsManager.get_fingerprint_for_name(name)`** -- new method, shaped after the existing `get_named_paths_uuid(name)` right above it (same `None`/`"#"`-fragment/`"$"`-reference handling), returning the last manifest entry's own `"fingerprint"` instead of `"uuid"`.
- **`ResultsMetadata.named_paths_fingerprint`** -- new attribute, wired into `from_manifest()`.
- **`ResultsRegistrar`** -- populates it in `register_start()` via the same `paths_manager` call pattern already used for the file-side fingerprint fetch; writes it in `metadata_update()`.
- **`NamedPathsFingerprint3`** -- new `RESULTS`-only field-accessor `Function3` subclass, `SOURCE = "manifest"`, `KIND = "fingerprint"` (comparable to `Fingerprint3`/`NamedFileFingerprint3` under UNION, per the already-settled KIND taxonomy), registered in the factory and in `reference_3.py`'s `_METADATA_FIELD_FUNCTIONS` tuple. No finder-specific code needed anywhere -- field accessors and UNION `KIND` comparison both read declaratively off the registered class.

Also wired into the **OTLP** results listener (a single additive dict key in an existing `core_meta()` override -- no schema involved).

**Deliberately left out, on request:** the SQLite/SQL results listeners already mirror `named_file_fingerprint` into their own DB schemas, but wiring `named_paths_fingerprint` in too would need real schema/DDL changes (a new `Sqliter` schema.sql column, a new SQLAlchemy `Column`) -- beyond what the bucket-list item actually specified (function + manifest field + registrar change). The field is still fully usable via `manifest.json` and the new function.

## Test plan

- [x] New `test_named_paths_fingerprint_3.py` (Function3 metadata/arg validation, mirrors `test_named_file_fingerprint_3.py`).
- [x] New `PathsManager.get_fingerprint_for_name` coverage in `test_csvpaths_managers_paths_manager.py` (happy path against a real registered group, `None`-name raise, no-manifest raise).
- [x] New `ResultsMetadata` coverage (`from_manifest` reads the field, defaults to `None`).
- [x] Extended `test_results_reference_finder_3.py`'s existing run-scope-fields test with the new field.
- [x] Extended `test_reference_expression_3.py`'s `orders_archive` fixture and added an end-to-end test proving the actual motivating case: `$groupa.csvpaths.:fingerprint()` UNION `$groupa.results.:flatten():named_paths_fingerprint()`.
- [x] `tests/references/` + `tests/csvpaths/managers/` + `tests/csvpaths/references/`: 1580 passed.
- [x] Full local-backend suite: 3045/3045 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
