### PR TITLE
Widen :having() to RESULTS -- filters the run pool, not just group versions

### DIFF
--- a/csvpath/references/functions/selectors/having_3.py
+++ b/csvpath/references/functions/selectors/having_3.py
@@ -16,19 +16,45 @@ class Having3(Function3):
     # groups by a condition on their own contents, as opposed to WHERE,
     # which filters rows) -- David's own framing.
     #
+    # Widened to RESULTS 2026-08-27 (deferred-work bucket-list entry,
+    # "':having()' is not yet built for RESULTS at all") -- the same
+    # underlying idea one level down: filters the candidate RUN pool
+    # down to runs that contain an instance (a csvpath statement result)
+    # with the given identity, using ResultsReferenceFinder3's own
+    # _list_instance_identities() (a filesystem listing, unlike
+    # CSVPATHS' own manifest-array membership check -- RESULTS has no
+    # equivalent "named_paths_identities" field to read, each run's own
+    # instance directories ARE the identity list). This is a real,
+    # previously-unbuilt capability, distinct from just using a literal
+    # identity in name_three -- a literal identity SELECTS one instance
+    # (returns the instance itself, silently empty for a non-matching
+    # run); ':having()' here rides in name_one, alongside a pointer like
+    # ':last()', and FILTERS which runs even qualify before the pointer
+    # picks one -- "the last run that had a header_checks statement,"
+    # returning the RUN, not the instance (references_v3_expressions.md's
+    # own Q&A distinguishes these two: INTERSECT-with-CSVPATHS for "give
+    # me the runs," ':having()' directly on RESULTS for "give me the
+    # instances" -- but the run-filtering shape here, confirmed with
+    # David 2026-08-27, is a third, equally real shape neither of those
+    # two examples covered explicitly).
+    #
     # ROLE is CONTEXT_SETTER, not POINTER -- it narrows the candidate
-    # version list without resolving to exactly one; a real pointer
+    # version/run list without resolving to exactly one; a real pointer
     # (":last()" etc.) riding alongside it reduces the FILTERED list,
     # the same "narrow, then optionally reduce" pattern ':all()'/
     # ':from()'/':to()' already use elsewhere in this codebase.
     #
     NAME = "having"
     SUMMARY = (
-        "Filters this named-paths group's versions down to those whose "
-        "own statement list contains a statement with this identity."
+        "Filters this named-paths group's versions, or (RESULTS) this "
+        "group's runs, down to those whose own statement/instance list "
+        "contains one with this identity."
     )
     ROLE = Function3.CONTEXT_SETTER
-    DATATYPES = (Reference3.CSVPATHS,)
+    DATATYPES = (Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (str,)
     ARG_REQUIRED = True
-    POSITIONS = {Reference3.CSVPATHS: (Reference3.NAME_ONE,)}
+    POSITIONS = {
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -402,6 +402,29 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ]
         candidates = sorted(candidates, key=self._run_dir_sort_key)
 
+        having_call = next(
+            (f for f in ReferenceFunctionFactory.build_chain(calls) if f.name == "having"),
+            None,
+        )
+        if having_call is not None:
+            # filters the run pool down to runs that contain an instance
+            # (a csvpath statement result) with this identity -- added
+            # 2026-08-27, mirroring CsvpathsReferenceFinder3's own
+            # ':having()' (manifest-array membership there; a real
+            # filesystem listing here, since RESULTS has no equivalent
+            # "named_paths_identities" field to read off a run). Applied
+            # BEFORE ':from()'/':to()'/the pointer reduce below, same
+            # position ':having()' occupies in CSVPATHS' own
+            # _resolve_versions(). group_key_for (if set) needs no
+            # separate trim -- its own consumer below only ever looks up
+            # keys for `rh in candidates`, so extra now-unused entries
+            # for filtered-out runs are simply never read.
+            candidates = [
+                rh
+                for rh in candidates
+                if having_call.arg in self._list_instance_identities(rh)
+            ]
+
         from_call, to_call = self._range_calls_from_calls(calls)
         if from_call is not None or to_call is not None:
             # ':from()'/':to()' as a run-level range -- added 2026-08-13,
@@ -610,7 +633,9 @@ class ResultsReferenceFinder3(ReferenceFinder3):
 
         if self._is_bare_function_only(name_one):
             calls = self._combined_name_one_calls(name_one)
-            pointer, all_call, flatten_call = self._star_run_selector_chain(calls)
+            pointer, all_call, flatten_call, having_call = self._star_run_selector_chain(
+                calls
+            )
             if all_call is not None:
                 # exactly one level, wildcarded -- the SAME [Star3()]
                 # restriction bare ':all()' already applies for one
@@ -629,7 +654,13 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                             (rh, (group, self._group_key(rh, home)))
                         )
                 return self._star_group_and_reduce(
-                    partitioned, pointer, identity, match_all, range_bounds, accessor
+                    partitioned,
+                    pointer,
+                    identity,
+                    match_all,
+                    range_bounds,
+                    accessor,
+                    having_call,
                 )
             if flatten_call is not None:
                 # any depth, every group -- _discover_run_homes(None)
@@ -655,7 +686,13 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                     )
                 ]
             return self._star_pool_and_reduce(
-                run_homes, pointer, identity, match_all, range_bounds, accessor
+                run_homes,
+                pointer,
+                identity,
+                match_all,
+                range_bounds,
+                accessor,
+                having_call,
             )
 
         if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
@@ -672,7 +709,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 )
             prefix_pattern = self._compile_path_pattern(name_one.path[:-1])
             calls = list(name_one.functions)
-            pointer, _, _ = self._star_run_selector_chain(calls)
+            pointer, _, _, having_call = self._star_run_selector_chain(calls)
             run_homes = [
                 rh
                 for rh, group in self._discover_run_homes(None)
@@ -683,7 +720,13 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 )
             ]
             return self._star_pool_and_reduce(
-                run_homes, pointer, identity, match_all, range_bounds, accessor
+                run_homes,
+                pointer,
+                identity,
+                match_all,
+                range_bounds,
+                accessor,
+                having_call,
             )
 
         if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
@@ -702,7 +745,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             prefix = self._compile_path_pattern(name_one.path[:-1])
             pattern = prefix + [Star3()]
             calls = list(name_one.functions)
-            pointer, _, _ = self._star_run_selector_chain(calls)
+            pointer, _, _, having_call = self._star_run_selector_chain(calls)
             partitioned = []
             for rh, group in self._discover_run_homes(None):
                 home = self.csvpaths.results_manager.get_named_results_home(group)
@@ -719,7 +762,13 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                         )
                     )
             return self._star_group_and_reduce(
-                partitioned, pointer, identity, match_all, range_bounds, accessor
+                partitioned,
+                pointer,
+                identity,
+                match_all,
+                range_bounds,
+                accessor,
+                having_call,
             )
 
         if isinstance(name_one.path[-1], FunctionCall3) and name_one.path[
@@ -737,7 +786,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # to each candidate's OWN group home), reduced by the pointer.
         pattern = self._compile_path_pattern(name_one.path)
         calls = list(name_one.functions)
-        pointer, _, _ = self._star_run_selector_chain(calls)
+        pointer, _, _, having_call = self._star_run_selector_chain(calls)
         run_homes = [
             rh
             for rh, group in self._discover_run_homes(None)
@@ -746,7 +795,13 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             )
         ]
         return self._star_pool_and_reduce(
-            run_homes, pointer, identity, match_all, range_bounds, accessor
+            run_homes,
+            pointer,
+            identity,
+            match_all,
+            range_bounds,
+            accessor,
+            having_call,
         )
 
     def _star_run_selector_chain(self, calls: list) -> tuple:
@@ -755,7 +810,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         and literal/'*'-prefixed alike) -- added 2026-08-19, factored
         out of what used to be inline-only-for-the-bare-case logic once
         the literal/'*'-prefixed shapes needed the identical validation.
-        Returns (pointer, all_call, flatten_call); all_call/flatten_call
+        Returns (pointer, all_call, flatten_call, having_call); all_call/flatten_call
         are only ever non-None for the bare shape (calls includes
         name_one.path[0] itself there) -- for a prefixed shape, calls is
         just name_one.functions, and the ':all()'/':flatten()' marker
@@ -774,6 +829,15 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         see home_3.py) rather than falling out of the field-accessor
         exemption above for free the way it used to when it still
         declared SOURCE == "manifest".
+
+        A run-filtering ':having("identity")' (added 2026-08-27,
+        mirroring CsvpathsReferenceFinder3's own star-traversal support)
+        is exempt the same way -- filters the candidate run pool down to
+        runs containing a matching instance, applied by the shared
+        _star_pool_and_reduce()/_star_group_and_reduce() tail methods
+        rather than here, since `built` alone (this method only ever
+        sees ONE candidate-gathering shape's own combined chain, not the
+        full run list to filter) has nothing to filter yet at this point.
 
         A pointer itself is now OPTIONAL here (changed 2026-08-19) --
         absence means "every matched run, unreduced," the SAME meaning
@@ -799,6 +863,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         flatten_call = next((f for f in built if f.name == "flatten"), None)
         manifest_call = next((f for f in built if f.name == "manifest"), None)
         home_call = next((f for f in built if f.name == "home"), None)
+        having_call = next((f for f in built if f.name == "having"), None)
         if all_call is not None and flatten_call is not None:
             raise ReferenceException3(
                 "ResultsReferenceFinder3 does not support combining "
@@ -814,6 +879,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             and f is not all_call
             and f is not manifest_call
             and f is not home_call
+            and f is not having_call
         ]
         if non_pointers:
             raise ReferenceException3(
@@ -821,11 +887,11 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 f":{non_pointers[0].name}() combined with '*' traversal -- "
                 "only a bare pointer (:first()/:last()/:index(n)), "
                 "optionally combined with ':all()'/':flatten()', :manifest(), "
-                "and/or a run-level field-accessor function (e.g. :uuid()), "
-                "is supported so far."
+                "':having(\"identity\")', and/or a run-level field-accessor "
+                "function (e.g. :uuid()), is supported so far."
             )
         pointer = self._pointer_from_calls(calls)
-        return pointer, all_call, flatten_call
+        return pointer, all_call, flatten_call, having_call
 
     def _star_pool_and_reduce(
         self,
@@ -835,10 +901,19 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         match_all: bool,
         range_bounds: tuple | None,
         accessor,
+        having_call=None,
     ) -> ReferenceResults3:
         """POOL mode's shared tail -- added 2026-08-19, alongside
         _star_group_and_reduce(), factored out once name_three needed
-        threading through every star-traversal shape identically. A
+        threading through every star-traversal shape identically.
+        `having_call` (added 2026-08-27) filters `run_homes` down to
+        runs containing an instance with the given identity, BEFORE the
+        pointer reduces -- applied here, centrally, rather than in each
+        of _query_star_traversal's own four candidate-gathering
+        branches, since every one of them already funnels into this
+        shared tail (or _star_group_and_reduce's, which applies the same
+        filter itself before delegating here for its own no-pointer
+        case). A
         missing pointer (added 2026-08-19, see _star_run_selector_chain()'s
         own comment for why) means every matched run comes back,
         unreduced -- which can now be MORE than one run. Resolving full
@@ -854,6 +929,12 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         all in THIS branch to worry about conflating with -- every
         matched run is genuinely unreduced, so the flag's own count
         check at resolve() time means exactly what it says."""
+        if having_call is not None:
+            run_homes = [
+                rh
+                for rh in run_homes
+                if having_call.arg in self._list_instance_identities(rh)
+            ]
         run_homes = sorted(run_homes, key=self._run_dir_sort_key)
         if pointer is None:
             results = []
@@ -884,10 +965,17 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         match_all: bool,
         range_bounds: tuple | None,
         accessor,
+        having_call=None,
     ) -> ReferenceResults3:
         """GROUP mode's shared tail (":all()", bare or literal/'*'-
         prefixed) -- added 2026-08-19. `partitioned`: list of
-        (run_home, composite_key) pairs. Unlike POOL mode, a pointer
+        (run_home, composite_key) pairs. `having_call` (added
+        2026-08-27) filters `partitioned` down to runs containing an
+        instance with the given identity, BEFORE partitioning/reducing
+        -- same position/reasoning as _star_pool_and_reduce's own copy
+        of this filter (not shared as one call, since the two methods
+        filter different-shaped inputs -- a flat list here vs. pairs).
+        Unlike POOL mode, a pointer
         here can still select MORE than one run overall (one per
         partition) -- so a name_three CONTENT accessor (:errors()/
         :vars()/etc, as opposed to a poolable field accessor like
@@ -913,6 +1001,12 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         "list everything, unreduced" case _star_pool_and_reduce()
         already handles -- delegated there directly rather than
         duplicating that logic."""
+        if having_call is not None:
+            partitioned = [
+                (rh, key)
+                for rh, key in partitioned
+                if having_call.arg in self._list_instance_identities(rh)
+            ]
         if accessor is not None and pointer is not None:
             # the content-accessor rejection only applies when grouping
             # can still yield more than one run (pointer present, one

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -321,11 +321,8 @@ and a stale-entry correction, are both done — see
 - `:groups()` combined with `'*'` traversal (RESULTS) — no established
   per-GROUP-of-named-results-groups meaning settled yet for the any-depth
   case.
-- `:having()` is not yet built for RESULTS at all (only CSVPATHS has it).
-  Real, wanted follow-up, not just aspirational — "give me all the runs
-  where the named-paths group included a csvpath with a given identity"
-  vs. "just give me the matching instances" both want this on RESULTS
-  directly. See `references_expressions.md`.
+- `:having()` for RESULTS — **BUILT 2026-08-27**, see
+  `deferred_work_done_list.md`.
 
 ## `'*'` traversal — FILES, essentially untouched by the recent RESULTS/CSVPATHS work
 

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,82 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `:having()` widened to RESULTS — BUILT 2026-08-27
+
+From the "'*' traversal — RESULTS/CSVPATHS remaining gap" bucket-list
+entry: `:having("identity")` existed for CSVPATHS only (filters a named-
+paths group's own version manifest to versions whose
+`named_paths_identities` contains the given identity, before any
+pointer reduces). RESULTS had no equivalent.
+
+**Clarified with David, 2026-08-27, before building** (a live-tested
+finding first suggested this might be redundant with existing
+capability -- worth recording since it changed the design): a literal
+identity in `name_three` combined with `'*'` traversal (e.g.
+`$*.results.:flatten().orders`) ALREADY does "every run's own `orders`
+instance, or nothing where absent" -- confirmed live, `_results_for_run()`'s
+`_find_by_identity()` lookup already returns `[]` (not an error) for a
+non-matching run. That is `references_v3_expressions.md`'s own "just
+give me the instances" framing for `:having()` on RESULTS, and it was
+already reachable.
+
+The REAL, previously-missing capability is different: `:having()` riding
+in `name_one` (the same *slot* CSVPATHS' own `:having()` occupies, e.g.
+`$acme.results.customers/2025:last():having("header_checks")`) as a
+`CONTEXT_SETTER` that filters the CANDIDATE RUN POOL down to runs
+containing a matching instance, BEFORE a pointer (`:last()` etc.)
+reduces that pool -- returns the matching RUN itself, not the instance.
+This is genuinely new: nothing in `results_reference_finder_3.py`
+recognized `:having()` at all before this build (confirmed via grep).
+`references_v3_expressions.md`'s own Q&A only worked out the
+INTERSECT-with-CSVPATHS shape ("give me the runs") and the "just the
+instances" shape (already redundant, per above) -- the run-*filtering*
+shape built here is a third, equally real case neither of those two
+examples covered explicitly.
+
+**Built, mirroring CSVPATHS' own `_resolve_versions()`/`_query_star_traversal()`
+precedent as closely as the two datatypes' different candidate shapes
+allow:**
+
+- **`Having3`** (`having_3.py`) widened -- `DATATYPES`/`POSITIONS` now
+  include `RESULTS: (NAME_ONE,)` alongside the existing CSVPATHS entry.
+  Same class, not a duplicate -- the underlying idea ("filter this
+  candidate pool by whether it contains a given identity") is identical,
+  just applied to a different candidate shape (run pool vs. group-
+  version manifest).
+- **Literal-root `query()`** (`results_reference_finder_3.py`) -- filters
+  `candidates` (a list of run_home strings) right after they are sorted,
+  before `:from()`/`:to()` range narrowing, using the new
+  `_list_instance_identities(rh)` check (a real filesystem listing --
+  RESULTS has no manifest-array field to read the way CSVPATHS'
+  `named_paths_identities` provides, each run's own instance
+  subdirectories ARE the identity list). `group_key_for` (`:all()`/
+  `:groups()` partitioning) needed no separate trim -- its own consumer
+  only ever looks up keys for `rh in candidates`, so stale entries for
+  filtered-out runs are simply never read.
+- **`'*'` traversal** -- `_star_run_selector_chain()` recognizes and
+  exempts `having_call` from the "unsupported function" rejection
+  (same treatment `all_call`/`flatten_call`/`manifest_call`/`home_call`/
+  `field_call` already get), and now returns it as a fourth tuple
+  element, threaded through all four of `_query_star_traversal()`'s own
+  candidate-gathering branches (bare, `:flatten()`-prefixed,
+  `:all()`-prefixed, plain literal/`'*'` path) into the two shared-tail
+  methods, `_star_pool_and_reduce()`/`_star_group_and_reduce()`, which
+  each apply the same `_list_instance_identities()` filter centrally
+  (once, not duplicated across the four branches) before their own
+  pointer/partition reduction. `_star_group_and_reduce()`'s own
+  no-pointer delegation to `_star_pool_and_reduce()` passes no
+  `having_call` (already filtered by that point) to avoid double-
+  filtering.
+
+Tests: widened `test_having_3.py`'s metadata assertions; new
+`TestHavingFiltersRunsByInstanceIdentity` (literal-root, using the
+existing `acme_archive` fixture's real identity split) and
+`TestStarTraversalHaving` (pool mode via bare pointer/`:flatten()`,
+grouped mode via `:all()`) in `test_results_reference_finder_3.py`.
+Full local-backend suite green (3055/3055, run twice); pre-existing
+SFTP/S3 env-dependent failures unrelated to this change.
+
 ## Results Run Manifest `named_paths_fingerprint` field — BUILT 2026-08-27 (closes issue #262)
 
 Surfaced by David, 2026-08-26, while correcting the UNION `KIND`

--- a/tests/references/functions/selectors/test_having_3.py
+++ b/tests/references/functions/selectors/test_having_3.py
@@ -10,7 +10,11 @@ def test_metadata():
     f = Having3(arg="my_validations")
     assert f.name == "having"
     assert f.ROLE == Function3.CONTEXT_SETTER
-    assert f.DATATYPES == (Reference3.CSVPATHS,)
+    assert f.DATATYPES == (Reference3.CSVPATHS, Reference3.RESULTS)
+    assert f.POSITIONS == {
+        Reference3.CSVPATHS: (Reference3.NAME_ONE,),
+        Reference3.RESULTS: (Reference3.NAME_ONE,),
+    }
 
 
 def test_str_arg_is_valid():

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -208,6 +208,52 @@ class TestVersionPointer:
         ]
 
 
+class TestHavingFiltersRunsByInstanceIdentity:
+    # ':having("identity")' widened to RESULTS 2026-08-27 (deferred-work
+    # bucket-list entry) -- mirrors CsvpathsReferenceFinder3's own
+    # ':having()' one level down: filters the candidate RUN pool to
+    # those containing an instance (csvpath statement result) with the
+    # given identity, BEFORE any pointer reduces. acme_archive's run1
+    # has "company_names"/"1"; run2 has only "0" -- proves filtering,
+    # not just "identity happens to exist somewhere."
+    def test_having_then_pointer_gives_the_qualifying_run(self, acme_archive):
+        results = _finder(
+            "$acme.results.customers/2025:last():having(\"company_names\")",
+            acme_archive,
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_order_of_pointer_and_having_does_not_matter(self, acme_archive):
+        results = _finder(
+            "$acme.results.customers/2025:having(\"company_names\"):last()",
+            acme_archive,
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_having_excludes_a_run_without_the_identity(self, acme_archive):
+        # run2 is chronologically last, but only run1 "has" company_names
+        # -- proves the filter really runs before the pointer, not after.
+        results = _finder(
+            "$acme.results.customers/2025:last():having(\"0\")", acme_archive
+        ).query()
+        assert results.uuids == ["run2-uuid"]
+
+    def test_having_with_no_matching_run_gives_empty(self, acme_archive):
+        results = _finder(
+            "$acme.results.customers/2025:last():having(\"nonexistent\")",
+            acme_archive,
+        ).query()
+        assert results.uuids == []
+
+    def test_having_with_no_pointer_returns_every_qualifying_run_unreduced(
+        self, acme_archive
+    ):
+        results = _finder(
+            "$acme.results.customers/2025:having(\"company_names\")", acme_archive
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+
 class TestNoPointerReturnsEveryRun:
     def test_no_pointer_returns_every_run_unreduced(self, acme_archive):
         results = _finder("$acme.results.customers/2025", acme_archive).query()
@@ -2326,6 +2372,117 @@ class TestStarTraversal:
         # on a bare star-traversal reference before this fix.
         result = _finder("$*.results.:last()", two_group_archive).resolve()
         assert result.results[0].data is None
+
+
+class TestStarTraversalHaving:
+    # ':having("identity")' widened to RESULTS star traversal 2026-08-27
+    # (same bucket-list entry as the literal-root case above) -- filters
+    # the candidate run pool, across every group, down to runs
+    # containing a matching instance, before the pointer/grouping
+    # reduces. Exercises both shared-tail methods: _star_pool_and_reduce
+    # (bare pointer/':flatten()') and _star_group_and_reduce (':all()').
+    def test_bare_pointer_with_having_finds_the_qualifying_run(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme",
+            "2026-01-01_00-00-00",
+            "acme-run-uuid",
+            {"orders": "acme-orders-uuid"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets",
+            "2026-01-02_00-00-00",
+            "widgets-run-uuid",
+            {"other": "widgets-other-uuid"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        # widgets is chronologically later, but only acme "has" orders --
+        # proves the pool is filtered before :last() reduces it.
+        results = _finder(
+            '$*.results.:having("orders"):last()', str(tmp_path)
+        ).query()
+        assert results.uuids == ["acme-run-uuid"]
+
+    def test_no_pointer_returns_every_qualifying_run_unreduced(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme",
+            "2026-01-01_00-00-00",
+            "acme-run-uuid",
+            {"orders": "acme-orders-uuid"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets",
+            "2026-01-02_00-00-00",
+            "widgets-run-uuid",
+            {"other": "widgets-other-uuid"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder('$*.results.:having("orders")', str(tmp_path)).query()
+        assert results.uuids == ["acme-run-uuid"]
+
+    def test_no_matching_run_gives_empty(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme",
+            "2026-01-01_00-00-00",
+            "acme-run-uuid",
+            {"orders": "acme-orders-uuid"},
+        )
+        _write_archive_manifest_multi(tmp_path, {"acme": [acme_run]})
+        results = _finder(
+            '$*.results.:having("nonexistent"):last()', str(tmp_path)
+        ).query()
+        assert results.uuids == []
+
+    def test_flatten_with_having_finds_the_qualifying_run_at_any_depth(
+        self, tmp_path
+    ):
+        acme_run = _make_run(
+            tmp_path / "acme" / "east",
+            "2026-01-01_00-00-00",
+            "acme-run-uuid",
+            {"orders": "acme-orders-uuid"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets",
+            "2026-01-02_00-00-00",
+            "widgets-run-uuid",
+            {"other": "widgets-other-uuid"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder(
+            '$*.results.:flatten():having("orders")', str(tmp_path)
+        ).query()
+        assert results.uuids == ["acme-run-uuid"]
+
+    def test_all_grouping_with_having_filters_before_partitioning(self, tmp_path):
+        # both groups have a one-level template, matching ':all()'s own
+        # exactly-one-level restriction -- widgets is filtered out by
+        # ':having()' entirely, so only acme's own (group, template)
+        # partition survives to be reduced.
+        acme_run = _make_run(
+            tmp_path / "acme" / "east",
+            "2026-01-01_00-00-00",
+            "acme-run-uuid",
+            {"orders": "acme-orders-uuid"},
+        )
+        widgets_run = _make_run(
+            tmp_path / "widgets" / "west",
+            "2026-01-02_00-00-00",
+            "widgets-run-uuid",
+            {"other": "widgets-other-uuid"},
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme": [acme_run], "widgets": [widgets_run]}
+        )
+        results = _finder(
+            '$*.results.:all():having("orders"):last()', str(tmp_path)
+        ).query()
+        assert results.uuids == ["acme-run-uuid"]
 
 
 class TestStarTraversalPathNarrowingAndNameThree:


### PR DESCRIPTION
## Summary

Closes a deferred-work bucket-list item ("`'*'` traversal — RESULTS/CSVPATHS remaining gap"): `:having("identity")` existed for CSVPATHS only.

**Before building, I live-tested the actual gap and it turned out to be different from what the design doc's own wording suggested** (worth recording, since it changed the design): a literal identity in `name_three` combined with `'*'` traversal (e.g. `$*.results.:flatten().orders`) *already* gives "every run's own `orders` instance, or nothing where that run doesn't have one" — confirmed live, `_results_for_run()`'s own `_find_by_identity()` lookup already returns `[]` (not an error) for a non-matching run. That's `references_v3_expressions.md`'s own "just give me the instances" framing for `:having()` on RESULTS — and it was already reachable, no new capability needed.

The **real, previously-missing** capability, clarified with David: `:having()` riding in `name_one` — the same *slot* CSVPATHS' own `:having()` occupies, e.g. `$acme.results.customers/2025:last():having("header_checks")` — as a `CONTEXT_SETTER` that filters the **candidate run pool** down to runs containing a matching instance, *before* a pointer (`:last()` etc.) reduces that pool. Returns the matching **run**, not the instance. Confirmed via grep that nothing in `results_reference_finder_3.py` recognized `:having()` at all before this — the design doc's own Q&A only worked out the INTERSECT-with-CSVPATHS shape ("give me the runs") and the already-redundant "just the instances" shape; the run-*filtering* shape built here is a third, equally real case neither example covered explicitly.

## What was built

Mirrors CSVPATHS' own `_resolve_versions()`/`_query_star_traversal()` precedent as closely as the two datatypes' different candidate shapes allow:

- **`Having3`** widened — `DATATYPES`/`POSITIONS` now include `RESULTS: (NAME_ONE,)` alongside CSVPATHS. Same class, not a duplicate — same underlying idea ("filter this candidate pool by whether it contains a given identity"), applied to a different candidate shape.
- **Literal-root `query()`** — filters `candidates` (run_home strings) right after sorting, before `:from()`/`:to()` range narrowing, via a new `_list_instance_identities(rh)` check (a real filesystem listing — RESULTS has no manifest-array field to read the way CSVPATHS' `named_paths_identities` does). `group_key_for` needed no separate trim — it's only ever looked up for `rh in candidates`.
- **`'*'` traversal** — `_star_run_selector_chain()` exempts `having_call` from the unsupported-function rejection and now returns it as a fourth tuple element, threaded through all four candidate-gathering branches into the two shared-tail methods (`_star_pool_and_reduce`/`_star_group_and_reduce`), which each apply the filter once, centrally, before their own pointer/partition reduction.

## Test plan

- [x] Widened `test_having_3.py`'s metadata assertions (both datatypes, both `POSITIONS`).
- [x] New `TestHavingFiltersRunsByInstanceIdentity` (literal-root, using the existing `acme_archive` fixture's real identity split).
- [x] New `TestStarTraversalHaving` (pool mode via bare pointer/`:flatten()`, grouped mode via `:all()`).
- [x] `tests/references/` + `tests/csvpaths/references/`: 1498 passed.
- [x] Full local-backend suite: 3055/3055 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
