### PR TITLE
Support a literal prefix before :flatten() for FILES

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -286,19 +286,39 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 )
             suffix_pattern = self._compile_path_pattern(name_one.path[1:])
             candidates = self._candidates_for_name_by_suffix(root_major, suffix_pattern)
-        # NOT YET BUILT, deferred 2026-08-12 (David wants it eventually,
-        # not now): a literal prefix BEFORE ':flatten()', e.g.
-        # "2025/:flatten()/:name('orders.csv')" -- "any orders.csv
-        # below 2025, at any depth in between." Falls through to the
-        # ordinary _compile_path_pattern branch below today, which
-        # raises cleanly (":flatten() as a name_one path segment" is
-        # unsupported there) rather than matching silently wrong -- see
-        # TestFlattenPrefixedWithSuffix::
-        # test_a_literal_prefix_before_flatten_is_not_yet_supported.
-        # Expected to be additive when built (a new elif keyed on
-        # ':flatten()' appearing at some position other than first),
-        # not a change to this bare-":flatten()"-first shape or to any
-        # non-prefixed path.
+        elif self._is_prefixed_flatten_reference(name_one):
+            # a literal/'*'/:name(...) PREFIX, THEN ':flatten()' at some
+            # OTHER position (not first -- that's the elif above), THEN
+            # an OPTIONAL literal/'*'/:name(...) SUFFIX -- built
+            # 2026-08-27, closing the gap deferred 2026-08-12 (David
+            # wants it eventually: "any orders.csv below 2025, at any
+            # depth in between," e.g. "2025/:flatten()/:name('orders.csv')").
+            # Purely additive, as originally scoped -- does not touch the
+            # bare or ':flatten()'-first shapes above, and only reachable
+            # when ':flatten()' is neither name_one's only segment nor
+            # its first one. A missing suffix (e.g. "2025/:flatten()"
+            # alone) falls out of the same matcher for free -- "prefix,
+            # then any depth, no further constraint" -- same "empty
+            # pattern is legal" convention _candidates_for_name(name, [])
+            # already uses elsewhere in this file, not a special case
+            # needing its own guard.
+            flatten_index = next(
+                i
+                for i, seg in enumerate(name_one.path)
+                if isinstance(seg, FunctionCall3) and seg.name == "flatten"
+            )
+            if name_one.path[flatten_index].arg is not None:
+                raise ReferenceException3(
+                    "FilesReferenceFinder3's ':flatten()' does not take an "
+                    "argument."
+                )
+            prefix_pattern = self._compile_path_pattern(name_one.path[:flatten_index])
+            suffix_pattern = self._compile_path_pattern(
+                name_one.path[flatten_index + 1 :]
+            )
+            candidates = self._candidates_for_name_by_prefix_and_suffix(
+                root_major, prefix_pattern, suffix_pattern
+            )
         else:
             pattern = self._compile_path_pattern(name_one.path)
             candidates = self._candidates_for_name(root_major, pattern)
@@ -755,6 +775,28 @@ class FilesReferenceFinder3(ReferenceFinder3):
             if self._matches_suffix(entry, home, suffix_pattern)
         ]
 
+    def _candidates_for_name_by_prefix_and_suffix(
+        self, name: str, prefix_pattern: list, suffix_pattern: list
+    ) -> list:
+        """every manifest entry for one named-file whose file_home's
+        LEADING segments match `prefix_pattern` AND (if non-empty)
+        TRAILING segments match `suffix_pattern`, with any number of
+        additional segments (including zero) allowed in between -- added
+        2026-08-27 for the "literal prefix BEFORE :flatten()" shape
+        (e.g. "2025/:flatten()/:name('orders.csv')"). An empty
+        `suffix_pattern` still matches -- "prefix, then any depth, no
+        further constraint" (a missing suffix, e.g. "2025/:flatten()"
+        alone)."""
+        manifest = self.csvpaths.file_manager.get_manifest(name)
+        home = self.csvpaths.file_manager.named_file_home(name).rstrip("/")
+        return [
+            entry
+            for entry in manifest
+            if self._matches_prefix_then_suffix(
+                entry, home, prefix_pattern, suffix_pattern
+            )
+        ]
+
     def _all_candidates_for_name(self, name: str) -> list:
         """every manifest entry for one named-file, at any path depth --
         ':flatten()'/':groups()' both match unconditionally, unlike a
@@ -911,6 +953,29 @@ class FilesReferenceFinder3(ReferenceFinder3):
             and isinstance(name_one.path[0], FunctionCall3)
             and name_one.path[0].name == "flatten"
         )
+
+    @staticmethod
+    def _is_prefixed_flatten_reference(name_one) -> bool:
+        """true when name_one's path contains exactly one bare
+        ':flatten()' call, NOT as the first segment (that is
+        _is_flatten_prefixed_reference's own shape, checked first) --
+        added 2026-08-27 for the "literal prefix BEFORE :flatten()"
+        shape, e.g. "2025/:flatten()/:name('orders.csv')". A second
+        ':flatten()' anywhere in the same path is not this shape (there
+        is no established meaning for two 'any depth' markers in one
+        pattern) -- correctly falls through to the ordinary
+        _compile_path_pattern path instead, which raises its own clear
+        "not a legal path segment" error for the second one. Does not
+        check the arg here, same reasoning
+        _is_flatten_prefixed_reference's own docstring gives -- query()
+        raises its own clear error for that once this shape is
+        confirmed."""
+        flatten_indices = [
+            i
+            for i, seg in enumerate(name_one.path)
+            if isinstance(seg, FunctionCall3) and seg.name == "flatten"
+        ]
+        return len(flatten_indices) == 1 and flatten_indices[0] > 0
 
     @staticmethod
     def _bare_definition_field_call(name_one) -> "FunctionCall3 | None":
@@ -1135,4 +1200,34 @@ class FilesReferenceFinder3(ReferenceFinder3):
         for actual, expected in zip(trailing, pattern):
             if not ReferenceFinder3._segment_matches(expected, actual):
                 return False
+        return True
+
+    @staticmethod
+    def _matches_prefix_then_suffix(
+        entry: dict, home: str, prefix_pattern: list, suffix_pattern: list
+    ) -> bool:
+        """like _matches_suffix, but ALSO requires file_home's own
+        relative segments to START WITH `prefix_pattern` -- the "literal
+        prefix BEFORE :flatten()" shape's own matcher (added
+        2026-08-27): a fixed prefix, then any depth, then an OPTIONAL
+        fixed suffix at the end. `suffix_pattern` may be empty (a
+        missing suffix, e.g. "2025/:flatten()" alone) -- in that case
+        only the prefix is checked, "any depth after it" with no further
+        constraint."""
+        file_home = entry["file_home"].rstrip("/")
+        if not file_home.startswith(home):
+            return False
+        rel = file_home[len(home) :].lstrip("/")
+        segments = rel.split("/") if rel else []
+        if len(segments) < len(prefix_pattern) + len(suffix_pattern):
+            return False
+        leading = segments[: len(prefix_pattern)]
+        for actual, expected in zip(leading, prefix_pattern):
+            if not ReferenceFinder3._segment_matches(expected, actual):
+                return False
+        if suffix_pattern:
+            trailing = segments[len(segments) - len(suffix_pattern) :]
+            for actual, expected in zip(trailing, suffix_pattern):
+                if not ReferenceFinder3._segment_matches(expected, actual):
+                    return False
         return True

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -357,12 +357,8 @@ and a stale-entry correction, are both done — see
 - FILES' `:all()`/`:groups()` (GROUP modes) combined with `:manifest()`/
   a field-accessor — same single-entity-vs-grouping restriction RESULTS'
   `name_three` content accessor now has, not yet built for FILES.
-- A literal prefix *before* `:flatten()` for FILES, e.g. `"2025/:flatten()
-  /:name('orders.csv')"` — "any `orders.csv` below 2025, at any depth in
-  between." Explicitly deferred 2026-08-12 — David wants it eventually,
-  not urgent. Falls through today to a clean rejection (not a silent wrong
-  answer). See `files_reference_finder_3.py` (`test_a_literal_prefix_
-  before_flatten_is_not_yet_supported`).
+- A literal prefix *before* `:flatten()` for FILES — **BUILT 2026-08-27**,
+  see `deferred_work_done_list.md`.
 - FILES' `:from()`/`:to()` combined with `:all()`/`:groups()` grouping in
   name_one — not yet supported.
 - A literal name_three body for FILES (bypassing a pointer function

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,67 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## A literal prefix before `:flatten()` for FILES — BUILT 2026-08-27
+
+From the FILES `'*'`-traversal bucket-list section: `:flatten()` was
+only recognized as name_one's own FIRST segment (`_is_flatten_prefixed_
+reference`, built 2026-08-12 -- any depth, THEN a fixed literal/`:name(...)`
+SUFFIX anchor) or as the whole of name_one (bare, any depth, no anchor
+at all). A THIRD shape -- a literal/`'*'`/`:name(...)` PREFIX, THEN
+`:flatten()`, THEN an OPTIONAL suffix (e.g.
+`"2025/:flatten()/:name('orders.csv')"` -- "any `orders.csv` below
+2025, at any depth in between") -- was explicitly deferred 2026-08-12,
+David wanting it eventually but not urgently. Fell through cleanly to
+`_compile_path_pattern`'s own "not a legal path segment" rejection
+before this, never matching silently wrong.
+
+**Built, purely additive as originally scoped -- does not touch the
+bare or `:flatten()`-first shapes:**
+
+- **`_is_prefixed_flatten_reference(name_one)`** (`files_reference_
+  finder_3.py`) -- true when exactly one bare `:flatten()` call appears
+  in `name_one.path`, NOT at index 0 (that is the existing
+  `_is_flatten_prefixed_reference`'s own shape, checked first via the
+  `elif` chain, so it always wins when `:flatten()` genuinely is
+  first). A second `:flatten()` anywhere is not this shape either --
+  falls through to the ordinary path with no special handling, which
+  raises its own clear error for the extra one (no established meaning
+  for two "any depth" markers in one pattern, not attempted).
+- **`_matches_prefix_then_suffix(entry, home, prefix_pattern,
+  suffix_pattern)`** (new static method, mirrors the existing
+  `_matches_suffix`'s own shape) -- requires the file_home's relative
+  segments to START WITH `prefix_pattern`, and (only if
+  `suffix_pattern` is non-empty) END WITH `suffix_pattern`, with any
+  number of segments (including zero) in between. An empty
+  `suffix_pattern` falls out for free as "prefix, then any depth, no
+  further constraint" -- e.g. `"2025/:flatten()"` alone -- the same
+  "empty pattern is legal" convention `_candidates_for_name(name, [])`
+  already uses elsewhere in this file, not a special case needing its
+  own guard.
+- **`_candidates_for_name_by_prefix_and_suffix`** -- thin wrapper
+  fetching the named-file's manifest and filtering by the matcher
+  above, mirroring `_candidates_for_name_by_suffix`'s own shape.
+
+Scoped to the literal-root `query()` case only, matching the concrete
+worked example exactly (`$anchor.files...`, not `$*.files...`) -- `'*'`
+traversal support for this same shape was not part of this ask and was
+not attempted.
+
+Tests: new `TestPrefixedFlatten` class (`test_files_reference_finder_3.py`)
+with a dedicated `PREFIXED_FLATTEN_MANIFEST` fixture proving: zero-gap
+and nonzero-gap matches both count, wrong prefix excludes, wrong suffix
+excludes, no-prefix-at-all excludes, `:last()`/`:first()` pick by array
+order same as every other FILES pointer, a missing suffix means
+"prefix then any depth," and an argument to `:flatten()` still raises.
+The old stale test asserting this always raised (`test_a_literal_
+prefix_before_flatten_is_not_yet_supported`, present in BOTH
+`test_files_reference_finder_3.py` and, found only by running the wider
+suite, a second copy in `test_normative_examples_files.py`) was updated
+in both places to assert the new, real behavior rather than deleted --
+confirms the same worked example is covered from the normative-examples
+angle too. Full local-backend suite green (3059/3059, run twice);
+pre-existing SFTP/S3 env-dependent failures unrelated to this change.
+
 ## `:having()` widened to RESULTS — BUILT 2026-08-27
 
 From the "'*' traversal — RESULTS/CSVPATHS remaining gap" bucket-list

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1113,26 +1113,102 @@ class TestFlattenPrefixedWithSuffix:
                 ANCHOR_MANIFEST,
             ).query()
 
-    def test_a_literal_prefix_before_flatten_is_not_yet_supported(self):
-        # a THIRD shape -- literal prefix, THEN ':flatten()', THEN a
-        # literal/:name(...) suffix (e.g. "2025/:flatten()/:name(...)"
-        # -- "any orders.csv below 2025, at any depth") -- is a real,
-        # separate extension David flagged wanting eventually, deferred
-        # 2026-08-12 rather than built now. ':flatten()' is only
-        # recognized as name_one's FIRST segment today
-        # (_is_flatten_prefixed_reference); anywhere else it falls
-        # through to the ordinary _compile_path_pattern path, which
-        # raises cleanly rather than silently matching wrong -- adding
-        # this later is expected to be additive (a new elif branch
-        # keyed on ':flatten()' appearing at some OTHER position in
-        # name_one.path) and should not touch any non-prefixed shape's
-        # behavior, including the bare/no-prefix ':flatten()/...' shape
-        # this class already covers.
+    # a literal prefix BEFORE ':flatten()' -- a THIRD shape, e.g.
+    # "2025/:flatten()/:name('orders.csv')" ("any orders.csv below 2025,
+    # at any depth in between") -- used to raise unconditionally here
+    # (deferred 2026-08-12); BUILT 2026-08-27, see TestPrefixedFlatten
+    # below for its own dedicated fixture/coverage.
+
+
+PREFIXED_FLATTEN_HOME = "inputs/named_files/vault"
+PREFIXED_FLATTEN_MANIFEST = [
+    {
+        "file": "inputs/named_files/vault/2025/orders.csv/aaa.csv",
+        "file_home": "inputs/named_files/vault/2025/orders.csv",
+        "uuid": "u-2025-direct",
+    },
+    {
+        "file": "inputs/named_files/vault/2025/q1/orders.csv/bbb.csv",
+        "file_home": "inputs/named_files/vault/2025/q1/orders.csv",
+        "uuid": "u-2025-q1",
+    },
+    {
+        "file": "inputs/named_files/vault/2026/orders.csv/ccc.csv",
+        "file_home": "inputs/named_files/vault/2026/orders.csv",
+        "uuid": "u-2026-direct",
+    },
+    {
+        "file": "inputs/named_files/vault/2025/returns.csv/ddd.csv",
+        "file_home": "inputs/named_files/vault/2025/returns.csv",
+        "uuid": "u-2025-returns",
+    },
+    {
+        "file": "inputs/named_files/vault/orders.csv/eee.csv",
+        "file_home": "inputs/named_files/vault/orders.csv",
+        "uuid": "u-no-prefix",
+    },
+]
+
+
+class TestPrefixedFlatten:
+    # a literal/'*'/:name(...) PREFIX, THEN ':flatten()', THEN an
+    # OPTIONAL literal/'*'/:name(...) SUFFIX -- built 2026-08-27, closing
+    # the gap deferred 2026-08-12 (David: "any orders.csv below 2025, at
+    # any depth in between"). PREFIXED_FLATTEN_MANIFEST has "orders.csv"
+    # directly under "2025" (zero-segment gap), under "2025/q1" (one-
+    # segment gap, proving "any depth in between"), under "2026" (wrong
+    # prefix -- must be excluded), "returns.csv" under "2025" (right
+    # prefix, wrong suffix -- must be excluded), and "orders.csv" with
+    # no prefix at all (must be excluded).
+    def test_matches_zero_and_nonzero_gap_but_not_wrong_prefix_or_suffix(self):
+        results = _finder(
+            '$vault.files.2025/:flatten()/:name("orders.csv")',
+            PREFIXED_FLATTEN_HOME,
+            PREFIXED_FLATTEN_MANIFEST,
+        ).query()
+        assert set(results.files) == {
+            "inputs/named_files/vault/2025/orders.csv",
+            "inputs/named_files/vault/2025/q1/orders.csv",
+        }
+
+    def test_last_picks_the_last_matching_entry_in_array_order(self):
+        results = _finder(
+            '$vault.files.2025/:flatten()/:name("orders.csv").:last()',
+            PREFIXED_FLATTEN_HOME,
+            PREFIXED_FLATTEN_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-2025-q1"]
+
+    def test_first_picks_the_first_matching_entry_in_array_order(self):
+        results = _finder(
+            '$vault.files.2025/:flatten()/:name("orders.csv").:first()',
+            PREFIXED_FLATTEN_HOME,
+            PREFIXED_FLATTEN_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-2025-direct"]
+
+    def test_missing_suffix_means_prefix_then_any_depth_no_further_constraint(
+        self,
+    ):
+        # "2025/:flatten()" alone -- prefix-only, no suffix anchor --
+        # matches every distinct file_home under "2025" at any depth,
+        # both orders.csv and returns.csv, but nothing under "2026" or
+        # with no prefix at all.
+        results = _finder(
+            "$vault.files.2025/:flatten()", PREFIXED_FLATTEN_HOME, PREFIXED_FLATTEN_MANIFEST
+        ).query()
+        assert set(results.files) == {
+            "inputs/named_files/vault/2025/orders.csv",
+            "inputs/named_files/vault/2025/q1/orders.csv",
+            "inputs/named_files/vault/2025/returns.csv",
+        }
+
+    def test_prefixed_flatten_rejects_an_argument(self):
         with pytest.raises(ReferenceException3):
             _finder(
-                '$anchor.files.2025/:flatten()/:name("orders.csv").:last()',
-                ANCHOR_HOME,
-                ANCHOR_MANIFEST,
+                '$vault.files.2025/:flatten("x")/:name("orders.csv")',
+                PREFIXED_FLATTEN_HOME,
+                PREFIXED_FLATTEN_MANIFEST,
             ).query()
 
 

--- a/tests/references/test_normative_examples_files.py
+++ b/tests/references/test_normative_examples_files.py
@@ -342,17 +342,19 @@ class TestFlattenPrefixedWithSuffix:
             "inputs/named_files/anchor/2025/orders.csv",
         }
 
-    def test_a_literal_prefix_before_flatten_is_not_yet_supported(self):
+    def test_a_literal_prefix_before_flatten_now_matches_only_that_prefix(self):
         # doc note: a literal prefix BEFORE ':flatten()' (e.g. "2025/
-        # :flatten()/:name(...)") is a real, deliberately deferred
-        # extension -- not built yet, confirmed to raise cleanly rather
-        # than match silently wrong.
-        with pytest.raises(ReferenceException3):
-            _finder(
-                '$anchor.files.2025/:flatten()/:name("orders.csv").:first()',
-                ANCHOR_HOME,
-                ANCHOR_MANIFEST,
-            ).query()
+        # :flatten()/:name(...)") -- BUILT 2026-08-27 (was deliberately
+        # deferred). Unlike the bare ':flatten()'-FIRST shape above
+        # (which pools both depths), the prefix restricts this to only
+        # the "2025/orders.csv" entry -- "orders.csv" with no "2025"
+        # prefix at all must NOT match.
+        results = _finder(
+            '$anchor.files.2025/:flatten()/:name("orders.csv").:first()',
+            ANCHOR_HOME,
+            ANCHOR_MANIFEST,
+        ).query()
+        assert results.uuids == ["u-one-pre-1"]
 
 
 class TestGroupsForOneNamedFile:


### PR DESCRIPTION
## Summary

Closes a deferred-work bucket-list item, deferred 2026-08-12: a literal/`'*'`/`:name(...)` **prefix** before `:flatten()` for FILES, e.g. `"2025/:flatten()/:name('orders.csv')"` — "any `orders.csv` below 2025, at any depth in between."

A third shape alongside the two already built: bare `:flatten()` (the whole of `name_one`, any depth, no anchor at all) and `:flatten()`-first (any depth, THEN a fixed suffix anchor). This one adds the prefix-anchored case. Used to fall through cleanly to `_compile_path_pattern`'s own "not a legal path segment" rejection; never matched silently wrong.

## What was built

Purely additive — does not touch the bare or `:flatten()`-first shapes, and scoped to the literal-root `query()` case only (matching the concrete worked example exactly, not `'*'` traversal):

- **`_is_prefixed_flatten_reference(name_one)`** — true when exactly one bare `:flatten()` call appears in `name_one.path`, not at index 0 (that's the existing shape, checked first). A second `:flatten()` anywhere falls through with no special handling — raises its own clear error, no established meaning for two "any depth" markers in one pattern.
- **`_matches_prefix_then_suffix(entry, home, prefix_pattern, suffix_pattern)`** — mirrors the existing `_matches_suffix`. Requires the leading segments to match `prefix_pattern`, and (only if non-empty) the trailing segments to match `suffix_pattern`, with any number of segments in between. An empty suffix falls out for free as "prefix, then any depth, no further constraint" — e.g. `"2025/:flatten()"` alone.
- **`_candidates_for_name_by_prefix_and_suffix`** — thin wrapper, mirrors `_candidates_for_name_by_suffix`.

## Test plan

- [x] New `TestPrefixedFlatten` class with a dedicated `PREFIXED_FLATTEN_MANIFEST` fixture — zero-gap and nonzero-gap matches both count, wrong prefix excludes, wrong suffix excludes, no-prefix-at-all excludes, `:last()`/`:first()` pick by array order (same as every other FILES pointer), a missing suffix means "prefix then any depth," argument to `:flatten()` still raises.
- [x] Found (via the wider suite, not just the target file) a **second copy** of the old "not yet supported" stub test in `test_normative_examples_files.py` — updated both to assert the new, real behavior.
- [x] `tests/references/` + `tests/csvpaths/references/`: 1502 passed.
- [x] Full local-backend suite: 3059/3059 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
