### PR TITLE
Support @variable as any function's own direct argument

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -164,7 +164,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         from_call = to_call = None
         if name_three is not None:
             if name_three.functions:
-                built = ReferenceFunctionFactory.build_chain(name_three.functions)
+                built = self._build_chain(name_three.functions)
                 # replaces a hand-written "unrecognized" check (settled
                 # 2026-08-14) -- see _check_position()'s own docstring
                 # and _resolve_versions()'s equivalent check for
@@ -342,7 +342,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         # combined with ':all()' (not a pointer-first shape) or a
         # 3+-function chain reaches the guard below.
         calls = [name_one.path[0], *name_one.functions]
-        built = ReferenceFunctionFactory.build_chain(calls)
+        built = self._build_chain(calls)
         all_call = next((f for f in built if f.name == "all"), None)
         is_grouped = all_call is not None
         having_call = next((f for f in built if f.name == "having"), None)
@@ -665,7 +665,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 "literal/'*' path-building is not meaningful for csvpaths."
             )
         calls = [name_one.path[0], *name_one.functions]
-        built = ReferenceFunctionFactory.build_chain(calls)
+        built = self._build_chain(calls)
         for f in built:
             self._check_position(f, Reference3.NAME_ONE, Reference3.CSVPATHS)
         having_call = next((f for f in built if f.name == "having"), None)

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -349,7 +349,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "body -- name_three must resolve to a pointer function "
                 "(:first()/:last()/:index(n))."
             )
-        built = ReferenceFunctionFactory.build_chain(name_three.functions)
+        built = self._build_chain(name_three.functions)
         for f in built:
             # replaces the old "at least one recognized category
             # present" gate below (settled 2026-08-14) -- that gate only
@@ -706,7 +706,7 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 "body -- name_three must resolve to a pointer function "
                 "(:first()/:last()/:index(n))."
             )
-        built = ReferenceFunctionFactory.build_chain(name_three.functions)
+        built = self._build_chain(name_three.functions)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         unsupported = (
             any(f.name == "manifest" for f in built)

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ..reference_3 import InterpolatedString3
+from ..reference_3 import InterpolatedString3, Variable3
 from ..reference_exceptions_3 import ReferenceException3
 
 
@@ -188,6 +188,19 @@ class Function3:
     def arg(self) -> Any:
         return self._arg
 
+    @arg.setter
+    def arg(self, value: Any) -> None:
+        """overwritten exactly once, by ReferenceFinder3._resolve_arg(),
+        right after ReferenceFunctionFactory builds this instance --
+        replaces a Variable3/InterpolatedString3 arg with its actual
+        resolved value (central, eager resolution, settled 2026-08-27),
+        so no other code anywhere -- any finder's own query()/
+        _extract_data() logic -- ever needs to know either of those two
+        "deferred" argument shapes exist; it just reads .arg and gets a
+        plain, already-resolved value. Not meant to be called anywhere
+        else."""
+        self._arg = value
+
     def check_valid(self) -> None:
         """structural check; doesn't test or use the arg's value. mirrors
         csvpath.matching.productions.matchable.Matchable.check_valid()'s
@@ -206,6 +219,23 @@ class Function3:
             allowed = self.ARG_TYPES
             if str in allowed and InterpolatedString3 not in allowed:
                 allowed = (*allowed, InterpolatedString3)
+            # any function that takes SOME argument also accepts an
+            # @variable, unconditionally -- added 2026-08-27, alongside
+            # ReferenceFinder3._build()/_build_chain()'s own central
+            # resolution. Unlike InterpolatedString3 (always resolves to
+            # a str, so only meaningful where str is already legal), a
+            # Variable3's resolved value could be ANY type -- a
+            # :regex()-style function taking (Regex3,) should accept
+            # @aregex just as readily as one taking (str,) should. This
+            # check is deliberately structural only ("is this shaped
+            # like an argument at all") -- it cannot know whether the
+            # RESOLVED value will actually satisfy ARG_TYPES, since
+            # resolution has not happened yet and may depend on a
+            # set_variable() call that has not even happened yet either.
+            # That check happens later, once the real value is known --
+            # see ReferenceRuntimeException3's own docstring.
+            if Variable3 not in allowed:
+                allowed = (*allowed, Variable3)
             if not isinstance(self._arg, allowed):
                 raise ReferenceException3(
                     f":{self.NAME}() argument must be one of {self.ARG_TYPES}, "

--- a/csvpath/references/reference_exceptions_3.py
+++ b/csvpath/references/reference_exceptions_3.py
@@ -4,3 +4,34 @@ class ReferenceException3(Exception):
     missing name_three where the reference's datatype requires one. see
     reference_grammar_3.py's module docstring for why that check is
     deferred out of the grammar."""
+
+
+class ReferenceRuntimeException3(ReferenceException3):
+    """raised for reference problems that can only be detected once a
+    reference is actually being resolved -- never by Function3.
+    check_valid()'s own parse-time structural check, which runs before
+    any @variable is necessarily even registered. Mirrors the matching
+    language's own static-vs-runtime split (csvpath/matching/functions/
+    args.py: Args.validate() raises ChildrenException for a syntax
+    problem, Args.matches() raises MatchException for a data problem
+    found while actually matching a line) -- added 2026-08-27, David:
+    "we just use a different exception that indicates a 'runtime'
+    error, as opposed to a static analysis error." Deliberately does
+    NOT bring over that split's other half, the error_manager/
+    do_i_raise() collect-vs-raise machinery -- references v3 has never
+    had that, every ReferenceException3 (this one included) has always
+    raised immediately, and nothing about the exception-class split
+    requires copying that too.
+
+    A subclass of ReferenceException3, not a sibling -- every existing
+    broad `except ReferenceException3`/`pytest.raises(ReferenceException3)`
+    keeps working completely unchanged; catch this narrower type
+    specifically when the static-vs-runtime distinction itself matters.
+
+    Two cases today, both in ReferenceFinder3: an `@variable` used in a
+    reference but never registered via set_variable()/set_variables()
+    (_resolve_value()), and a variable that WAS registered but resolved
+    to a value of the wrong type for the argument slot it was given in
+    (_resolve_arg() -- Function3.check_valid() cannot catch this itself,
+    since ARG_TYPES was widened to accept Variable3 unconditionally
+    precisely because its eventual resolved value could be anything)."""

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
 
+from .functions.function_3 import Function3
 from .functions.reference_function_factory_3 import ReferenceFunctionFactory
 from .reference_3 import (
     FunctionCall3,
@@ -15,7 +16,7 @@ from .reference_3 import (
     Star3,
     Variable3,
 )
-from .reference_exceptions_3 import ReferenceException3
+from .reference_exceptions_3 import ReferenceException3, ReferenceRuntimeException3
 from .reference_parser_3 import ReferenceParser3
 from .reference_results_3 import ReferenceResult3, ReferenceResults3
 
@@ -510,8 +511,13 @@ class ReferenceFinder3(ABC):
         for segment in path:
             if isinstance(segment, FunctionCall3):
                 if segment.name == "name":
-                    built = ReferenceFunctionFactory.build(segment)
-                    pattern.append(self._resolve_value(built.arg))
+                    # self._build() already resolves a Variable3/
+                    # InterpolatedString3 arg in place (added
+                    # 2026-08-27) -- built.arg is already the final,
+                    # plain value here, no separate _resolve_value()
+                    # call needed anymore.
+                    built = self._build(segment)
+                    pattern.append(built.arg)
                     continue
                 function_cls = ReferenceFunctionFactory.get_registered_class(
                     segment.name
@@ -523,7 +529,7 @@ class ReferenceFinder3(ABC):
                         "clock value function (e.g. :year()), and "
                         "literal/'*' segments are supported."
                     )
-                built = ReferenceFunctionFactory.build(segment)
+                built = self._build(segment)
                 pattern.append(str(built.compute()))
             elif isinstance(segment, (str, Star3)):
                 pattern.append(segment)
@@ -555,19 +561,39 @@ class ReferenceFinder3(ABC):
 
     def _resolve_value(self, value):
         """returns `value` unchanged if it is a plain literal (str, int,
-        etc.); evaluates it if it is an InterpolatedString3 -- each
-        literal-str part passes through, each FunctionCall3 part is
-        built and its compute() called (only SOURCE == "clock"
-        functions are legal inside "{...}" for now -- see
-        InterpolatedString3.check_valid(), which already restricts
-        parts to ROLE == VALUE; a non-clock VALUE function landing here
-        would mean check_valid() itself needs widening first, so this
-        raises a clear error rather than silently mishandling it), each
-        Variable3 part is looked up in this finder's own registered
+        etc.); resolves it if it is a bare Variable3 (added 2026-08-27,
+        alongside _build()/_build_chain() -- returns the RAW registered
+        value, untouched, unlike the InterpolatedString3 case below,
+        since a bare argument (e.g. :regex(@aregex)) may need to stay a
+        real Regex3/int/whatever, not become text); evaluates it if it
+        is an InterpolatedString3 -- each literal-str part passes
+        through, each FunctionCall3 part is built and its compute()
+        called (only SOURCE == "clock" functions are legal inside
+        "{...}" for now -- see InterpolatedString3.check_valid(), which
+        already restricts parts to ROLE == VALUE; a non-clock VALUE
+        function landing here would mean check_valid() itself needs
+        widening first, so this raises a clear error rather than
+        silently mishandling it), each Variable3 PART is looked up the
+        same way and stringified (interpolation always assembles one
+        final string, unlike the bare-argument case above). Both
+        Variable3 lookups read this finder's own registered
         self._variables (added 2026-08-26, compendium 3.12 -- "a
         reference finder can be given variables"; see set_variable()/
-        set_variables()), each part joined into one final string.
-        Instance method so this lookup has something to read from."""
+        set_variables()) and raise ReferenceRuntimeException3 (not the
+        plain ReferenceException3 this used before 2026-08-27) if unset
+        -- a reference using an unregistered @variable is not
+        malformed, it is missing a runtime value it needs, the same
+        static-vs-runtime distinction _resolve_arg() draws for a
+        variable's resolved value having the wrong type. Instance
+        method so this lookup has something to read from."""
+        if isinstance(value, Variable3):
+            if value.name not in self._variables:
+                raise ReferenceRuntimeException3(
+                    f"@{value.name} has no registered value -- call "
+                    "set_variable()/set_variables() on this finder "
+                    "before resolving a reference that uses it."
+                )
+            return self._variables[value.name]
         if not isinstance(value, InterpolatedString3):
             return value
         pieces = []
@@ -584,11 +610,11 @@ class ReferenceFinder3(ABC):
                         "\"{...}\" interpolation yet -- only clock value "
                         "functions (e.g. :year()) are supported so far."
                     )
-                built = ReferenceFunctionFactory.build(part)
+                built = self._build(part)
                 pieces.append(str(built.compute()))
             elif isinstance(part, Variable3):
                 if part.name not in self._variables:
-                    raise ReferenceException3(
+                    raise ReferenceRuntimeException3(
                         f"@{part.name} has no registered value -- call "
                         "set_variable()/set_variables() on this finder "
                         "before resolving a reference that uses it."
@@ -600,6 +626,65 @@ class ReferenceFinder3(ABC):
                     "interpolation."
                 )
         return "".join(pieces)
+
+    def _build(self, call: FunctionCall3) -> Function3:
+        """ReferenceFunctionFactory.build(), plus resolving this
+        function's own arg in place -- added 2026-08-27 (David:
+        "central eager resolve of args is right, certainly for now, at
+        least"). A Variable3/InterpolatedString3 arg becomes its real,
+        already-resolved value here, once, so no other code in any
+        finder ever needs to know either of those two "deferred"
+        argument shapes exist -- it just reads .arg and gets a plain
+        value, exactly as it always could before @variable existed.
+        Every call site that used to call ReferenceFunctionFactory.
+        build()/build_chain() directly now calls this/`_build_chain()`
+        instead -- a mechanical swap, not a behavior change for any
+        existing (non-variable) reference, since _resolve_arg() is a
+        no-op whenever an arg is neither of those two shapes."""
+        built = ReferenceFunctionFactory.build(call)
+        self._resolve_arg(built)
+        return built
+
+    def _build_chain(self, calls: list) -> list:
+        """ReferenceFunctionFactory.build_chain(), plus resolving every
+        function's own arg in place -- see _build()'s own docstring."""
+        built = ReferenceFunctionFactory.build_chain(calls)
+        for f in built:
+            self._resolve_arg(f)
+        return built
+
+    def _resolve_arg(self, built: Function3) -> None:
+        """the actual per-function resolution step shared by _build()/
+        _build_chain() -- added 2026-08-27. Recurses into a nested
+        function's own arg first (ReferenceFunctionFactory.build()'s
+        own recursion already compiled it into a Function3 before this
+        runs, so e.g. :errors(:idchain(@pattern))'s inner :idchain()
+        gets the same treatment as any top-level call). Structural type
+        validation of the arg's own SHAPE already happened inside
+        build()'s check_valid() call, against Variable3/
+        InterpolatedString3 themselves (Function3.check_valid()'s own
+        ARG_TYPES widening) -- it could not check the RESOLVED value's
+        own type, since resolution had not happened yet, and might
+        never happen at all if set_variable() is never called. That
+        check happens here instead, now that the real value is known --
+        raises ReferenceRuntimeException3, not a plain
+        ReferenceException3, since the reference itself was perfectly
+        well-formed; only a variable's own runtime value did not
+        satisfy it (see that exception class's own docstring)."""
+        if isinstance(built.arg, Function3):
+            self._resolve_arg(built.arg)
+            return
+        if not isinstance(built.arg, (Variable3, InterpolatedString3)):
+            return
+        original = built.arg
+        resolved = self._resolve_value(original)
+        if built.ARG_TYPES and not isinstance(resolved, built.ARG_TYPES):
+            allowed = ", ".join(t.__name__ for t in built.ARG_TYPES)
+            raise ReferenceRuntimeException3(
+                f":{built.name}() argument {original} resolved to a "
+                f"{type(resolved).__name__}, expected one of ({allowed})"
+            )
+        built.arg = resolved
 
     @staticmethod
     def _pointer_present(calls: list) -> bool:

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -218,7 +218,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         # name_one's own PATH-BUILDING segments (literal/'*'/:name()) --
         # those are already safe, validated separately and correctly by
         # the shared ReferenceFinder3._compile_path_pattern().
-        for f in ReferenceFunctionFactory.build_chain(calls):
+        for f in self._build_chain(calls):
             self._check_position(f, Reference3.NAME_ONE, Reference3.RESULTS)
         pointer = self._pointer_from_calls(calls)
         is_grouped = any(
@@ -403,7 +403,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         candidates = sorted(candidates, key=self._run_dir_sort_key)
 
         having_call = next(
-            (f for f in ReferenceFunctionFactory.build_chain(calls) if f.name == "having"),
+            (f for f in self._build_chain(calls) if f.name == "having"),
             None,
         )
         if having_call is not None:
@@ -857,7 +857,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         mode but not GROUP/':all()' mode, an asymmetry noted but not
         touched (a separate, already-merged PR, not blocking anything
         needed here)."""
-        built = ReferenceFunctionFactory.build_chain(calls)
+        built = self._build_chain(calls)
         field_call = self._find_field_function_call(built)
         all_call = next((f for f in built if f.name == "all"), None)
         flatten_call = next((f for f in built if f.name == "flatten"), None)
@@ -1402,30 +1402,34 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             and name_one.path[0].name != "name"
         )
 
-    @staticmethod
-    def _pointer_from_calls(calls: list):
+    def _pointer_from_calls(self, calls: list):
         """at most one pointer function (:first()/:last()/:index(n))
         among the combined chain selects which run -- build_chain()
         already enforces the "at most one" rule; absent means every run
-        comes back unreduced."""
+        comes back unreduced. Instance method (not a staticmethod,
+        since 2026-08-27) purely because self._build_chain() now needs
+        this finder's own registered variables to resolve any @variable
+        argument -- callers already invoke this as self._pointer_from_
+        calls(...) everywhere, so nothing else changes."""
         if not calls:
             return None
-        built = ReferenceFunctionFactory.build_chain(calls)
+        built = self._build_chain(calls)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
         return pointers[0] if pointers else None
 
-    @staticmethod
-    def _range_calls_from_calls(calls: list) -> tuple:
+    def _range_calls_from_calls(self, calls: list) -> tuple:
         """(from_call, to_call) -- the built ':from()'/':to()' Function3
         instances among the combined chain, or None for whichever is
         absent. Neither is a POINTER (both ROLE == CONTEXT_SETTER), so
         they never compete with a real pointer for build_chain()'s "at
         most one pointer" rule -- a pointer riding alongside either one
         reduces the SLICE ':from()'/':to()' already narrowed to, same as
-        it already does for ':all()'/':groups()'."""
+        it already does for ':all()'/':groups()'. Instance method (not
+        a staticmethod, since 2026-08-27), same reason as
+        _pointer_from_calls() above."""
         if not calls:
             return None, None
-        built = ReferenceFunctionFactory.build_chain(calls)
+        built = self._build_chain(calls)
         from_call = next((f for f in built if f.name == "from"), None)
         to_call = next((f for f in built if f.name == "to"), None)
         return from_call, to_call
@@ -1476,8 +1480,8 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         "file",
     )
 
-    @staticmethod
     def _name_three_selector(
+        self,
         name_three,
     ) -> tuple[str | None, bool, object, object, tuple]:
         """returns (identity, match_all, accessor, field_call,
@@ -1509,7 +1513,10 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         build_chain() itself ("Unknown reference function") if it is
         not registered at all, or is rejected here directly if it is
         registered but not meaningful as a name_three function (e.g.
-        :manifest())."""
+        :manifest()). Instance method (not a staticmethod, since
+        2026-08-27), same reason as _pointer_from_calls()'s own
+        docstring: self._build_chain() needs this finder's own
+        registered variables."""
         if name_three is None:
             return None, False, None, None, None
 
@@ -1519,7 +1526,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         from_call = None
         to_call = None
         if name_three.functions:
-            built = ReferenceFunctionFactory.build_chain(name_three.functions)
+            built = self._build_chain(name_three.functions)
             field_call = ResultsReferenceFinder3._find_field_function_call(built)
             for f in built:
                 if f.name == "all":

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -299,18 +299,38 @@ a named worksheet across every named-file matched by `'*'`.
   regex would select among *distinct named-files/groups themselves*
   (root_major's own job), not a path segment *within* one already-
   chosen entity, and would need real grammar changes plus a decision on
-  how it composes with `'*'` traversal's own existing semantics — left
-  alone, not attempted.
+  how it composes with `'*'` traversal's own existing semantics.
+
+  **Design settled 2026-08-27 (David), not yet built:**
+  - Function-only, no bare `/pattern/` form at `root_major` — consistent
+    with the grammar's existing invariant that `REGEX` only ever appears
+    inside `arg` (an argument value), never occupying a whole
+    grammatical slot on its own; `:regex(/pattern/)`/`:regex("pattern")`/
+    `:regex(@aregex)` are legal, a bare `/pattern/` directly as
+    `root_major` is not.
+  - Symmetric across all three datatypes (FILES/CSVPATHS/RESULTS), not
+    FILES-only — the crowded-namespace motivation (`acme_orders`/
+    `acme_invoices`/`abba_invoices`, disambiguating by partner-name
+    prefix) applies identically to named-paths/named-results groups.
+  - Composition with `'*'` traversal: a `:regex()` root_major is
+    structurally "every named-file/group whose name matches this
+    pattern" -- the same candidate-gathering `_query_star_traversal()`
+    already does for `'*'` (enumerating `named_file_names`/
+    `named_paths_names`/etc.), just pre-filtered by the pattern before
+    enumeration, not a new traversal mode.
+  - Real dependency, not an afterthought: `:regex(@aregex)` needs
+    `@variable` to work as `:regex()`'s own direct argument — **now
+    built**, see the entry immediately below and
+    `deferred_work_done_list.md`.
+  Still not built: the grammar change (`root_major` needs a function
+  alternative), the `Regex3`-producing `:regex()` function itself
+  (nothing like it exists anywhere in v3 yet), and the traversal-filter
+  threading through each finder's own name-enumeration call sites.
 - `@variable` (`Variable3`) registration and `{...}` interpolation
   evaluation are both **built 2026-08-26** — see `deferred_work_done_list.md`.
-  Still not built: `@variable` used as some OTHER function's *own direct
-  argument* (e.g. a hypothetical `:uuid(@myvar)`, per the dual-selector/
-  value-accessor entry above) — no currently-registered function's
-  `ARG_TYPES` includes `Variable3` at all. This is a separate,
-  independent gap from interpolation, not shared machinery — nothing
-  about the registration API or `_resolve_value()` built for
-  interpolation would need to change to also cover this, it is a
-  per-function `ARG_TYPES` question.
+  `@variable` used as some OTHER function's *own direct argument* (e.g.
+  `:having(@id)`, `:regex(@aregex)` once that function exists) — **BUILT
+  2026-08-27**, see `deferred_work_done_list.md`.
 
 ## `'*'` traversal — RESULTS/CSVPATHS remaining gap
 

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,131 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `@variable` as some other function's own direct argument — BUILT 2026-08-27
+
+From the "grammar / argument-type gaps" bucket-list entry: `@variable`
+registration and `{...}` interpolation evaluation were built 2026-08-26,
+but a *bare* `@variable` used directly as some OTHER function's own
+argument (e.g. `:having(@id)`, the motivating case for a future
+`:regex(@aregex)`) was not -- no registered function's `ARG_TYPES`
+included `Variable3`, and even if one had, nothing resolved a bare
+`Variable3` to its real value (only `Variable3` *parts* nested inside an
+`InterpolatedString3` were resolved). Surfaced while scoping the
+`:regex()` root_major design (see that bucket-list entry) -- David:
+"many functions need to support variable arguments... what does making
+variables complete entail?"
+
+**Two decisions settled first, before building (David, 2026-08-27):**
+- Reference-level `@variable`s (this simple, explicit `set_variable()`/
+  `set_variables()` dict registration) must NEVER be tied to a live
+  running CsvPath instance's own runtime variables -- even in the
+  uncertain future case of v3 references being used as productions
+  within csvpath statements, only copy-by-value between the two, never
+  a shared pointer. Already true in the code (`ReferenceFinder3.__init__`'s
+  own comment); now also an explicit design constraint for any future
+  work in this area, not just an implementation detail.
+- Central, eager resolution (resolve every function's own arg once,
+  right after it is built, before any finder logic touches `.arg`) over
+  resolving lazily at each of the many places a finder reads some
+  function's `.arg` -- "certainly for now, at least."
+
+**Built:**
+
+- **`ReferenceRuntimeException3`** (new, `reference_exceptions_3.py`) --
+  a subclass of `ReferenceException3` (not a sibling, so every existing
+  broad `except`/`pytest.raises(ReferenceException3)` keeps working
+  unchanged), for problems only detectable at resolve time, not by
+  `check_valid()`'s parse-time structural check. Mirrors the matching
+  language's own static-vs-runtime split (`csvpath/matching/functions/
+  args.py`: `Args.validate()` raises `ChildrenException` for a syntax
+  problem, `Args.matches()` raises `MatchException` for a data problem
+  found while matching) -- David: "we just use a different exception
+  that indicates a 'runtime' error, as opposed to a static analysis
+  error." Deliberately does NOT bring over that split's other half, the
+  `error_manager`/`do_i_raise()` collect-vs-raise machinery -- references
+  v3 has never had that, every `ReferenceException3` (this one included)
+  always raises immediately. Two raise sites: an `@variable` used but
+  never registered (`_resolve_value()`, both the bare-argument and the
+  interpolation-part case -- the interpolation case's own existing raise
+  was reclassified from the plain `ReferenceException3` it used before
+  this, for the same reason), and a registered variable that resolved to
+  a value of the wrong type for its argument slot (`_resolve_arg()`).
+- **`Function3.check_valid()`** widened -- any function with a non-empty
+  `ARG_TYPES` now also accepts a bare `Variable3`, unconditionally (not
+  gated on `str` being in `ARG_TYPES`, unlike the existing
+  `InterpolatedString3` widening right above it in the same method --
+  reused that widening's *shape*, not its condition, since a variable's
+  resolved value could be any type, not just string-shaped). A function
+  declaring no argument at all (`ARG_TYPES = ()`) still rejects a
+  `Variable3` too, same as any other arg. Purely structural, same as
+  every other `check_valid()` check -- it cannot and does not check
+  whether the eventual resolved value will actually satisfy `ARG_TYPES`.
+- **`Function3.arg`** gained a setter -- overwritten exactly once, by the
+  new central-resolution step below, replacing a `Variable3`/
+  `InterpolatedString3` arg with its real resolved value in place.
+- **`ReferenceFinder3._resolve_value()`** gained a new top-level branch
+  for a bare `Variable3` (as opposed to one nested inside an
+  `InterpolatedString3`'s own `.parts`, already handled) -- returns the
+  RAW registered value, NOT stringified, unlike the interpolation-part
+  case (which always assembles one final string) -- `:regex(@aregex)`
+  needs `@aregex` to stay a real `Regex3`, not become `"/pattern/"` as
+  text.
+- **`ReferenceFinder3._build()`/`_build_chain()`** (new) -- wrap
+  `ReferenceFunctionFactory.build()`/`build_chain()`, then resolve the
+  built function's own arg in place via a new `_resolve_arg()` helper.
+  Recurses into a nested function's own arg too (e.g.
+  `:errors(:idchain(@pattern))` -- `ReferenceFunctionFactory.build()`
+  already compiles the inner `:idchain()` into a real `Function3`
+  before the outer `:errors()` is constructed, so `_resolve_arg()`
+  follows the same nesting to reach it). `_resolve_arg()` is where the
+  DEFERRED type check finally happens -- once the real resolved value is
+  known, checked against `ARG_TYPES`, raising `ReferenceRuntimeException3`
+  (not a plain `ReferenceException3`) on a mismatch, since the reference
+  itself was perfectly well-formed; only the variable's own runtime
+  value did not satisfy it.
+- **All 14 existing call sites** across `reference_finder_3.py` and the
+  three concrete finders that used to call `ReferenceFunctionFactory.
+  build()`/`build_chain()` directly now call `self._build()`/
+  `self._build_chain()` instead -- a mechanical swap, verified to be
+  behavior-neutral for every existing (non-variable) reference by the
+  full suite staying green throughout. Three methods that used to be
+  `@staticmethod`s (`ResultsReferenceFinder3._pointer_from_calls()`,
+  `_range_calls_from_calls()`, `_name_three_selector()`) became instance
+  methods, since `self._build_chain()` needs a finder's own registered
+  variables -- every existing call site already used `self.`, so this
+  was safe. `ReferenceFinder3._compile_path_pattern()`'s own `:name(...)`
+  handling, the ORIGINAL sole consumer of `_resolve_value()`, was
+  simplified to drop its now-redundant manual `_resolve_value(built.arg)`
+  call -- `self._build()` already resolves it.
+
+**Deliberately NOT built, on request:** wiring reference-level variables
+into a live, running CsvPath instance's own runtime variable store
+(`variables`/`csvpath`/`headers`/`metadata`, the current v2 runtime-
+reference concepts) -- explicitly ruled out as a goal here, and separate
+from and much bigger than this work regardless (overlaps the standing
+"v3 is not wired into production" item below). This work is scoped
+entirely to the simple, explicit `set_variable()`/`set_variables()` dict
+model that already existed.
+
+**Not built either, still on the bucket list:** `:regex()` itself (the
+root_major function this whole scoping exercise was originally
+motivated by) -- this work unblocks `:regex(@aregex)` specifically, it
+does not build `:regex()`.
+
+Tests: widened `test_function_3.py` (Variable3 accepted for str-typed
+AND int-typed `ARG_TYPES`, still rejected for no-arg functions, new
+`arg` setter coverage); new `test_reference_exceptions_3.py`
+(`ReferenceRuntimeException3` subclass relationship); widened
+`TestResolveValue` and new `TestBuildAndResolveArg` in
+`test_reference_finder_3.py` (bare-variable resolution, unregistered
+raise, `_build()`/`_build_chain()` resolving in place, wrong-resolved-
+type raise, nested-function-arg resolution); new end-to-end test in
+`test_results_reference_finder_3.py` (`$acme.results.customers/
+2025:last():having(@id)` against a real fixture, same result as the
+literal-string version). Full local-backend suite green (3074/3074, run
+twice); pre-existing SFTP/S3 env-dependent failures unrelated to this
+change.
+
 ## A literal prefix before `:flatten()` for FILES — BUILT 2026-08-27
 
 From the FILES `'*'`-traversal bucket-list section: `:flatten()` was

--- a/tests/references/functions/test_function_3.py
+++ b/tests/references/functions/test_function_3.py
@@ -87,6 +87,37 @@ class TestCheckValid:
         with pytest.raises(ReferenceException3):
             _OptionalStrArgFunction(arg=bad).check_valid()
 
+    def test_str_typed_arg_accepts_a_bare_variable(self):
+        # added 2026-08-27 -- any function with a non-empty ARG_TYPES
+        # also accepts a bare @variable, unconditionally (unlike the
+        # str-gated InterpolatedString3 widening above) -- the resolved
+        # value could be any type, checked later at resolve time, not
+        # here.
+        _OptionalStrArgFunction(arg=Variable3(name="company")).check_valid()
+
+    def test_int_typed_arg_also_accepts_a_bare_variable(self):
+        # proves the widening is unconditional, not just for str-typed
+        # functions -- an int-only function accepts @var just as
+        # readily.
+        _RequiredIntArgFunction(arg=Variable3(name="n")).check_valid()
+
+    def test_no_arg_function_still_rejects_a_bare_variable(self):
+        # the Variable3 widening only applies once ARG_TYPES is
+        # non-empty -- a function declaring it takes no argument at all
+        # must still reject one, @variable included.
+        with pytest.raises(ReferenceException3):
+            _NoArgFunction(arg=Variable3(name="x")).check_valid()
+
+
+class TestArgSetter:
+    def test_arg_can_be_overwritten_after_construction(self):
+        # added 2026-08-27 for ReferenceFinder3._resolve_arg()'s own
+        # central, eager resolution -- a Variable3/InterpolatedString3
+        # arg gets replaced in place with its real resolved value.
+        f = _OptionalStrArgFunction(arg=Variable3(name="company"))
+        f.arg = "acme"
+        assert f.arg == "acme"
+
 
 class TestProperties:
     def test_name_and_arg(self):

--- a/tests/references/test_reference_exceptions_3.py
+++ b/tests/references/test_reference_exceptions_3.py
@@ -1,0 +1,21 @@
+from csvpath.references.reference_exceptions_3 import (
+    ReferenceException3,
+    ReferenceRuntimeException3,
+)
+
+
+class TestReferenceRuntimeException3:
+    # added 2026-08-27, David: "we just use a different exception that
+    # indicates a 'runtime' error, as opposed to a static analysis
+    # error" -- mirrors the matching language's own Args.validate()/
+    # Args.matches() (ChildrenException/MatchException) split.
+    def test_is_a_subclass_of_reference_exception_3(self):
+        # a subclass, not a sibling, so every existing broad
+        # `except ReferenceException3` keeps working unchanged.
+        assert issubclass(ReferenceRuntimeException3, ReferenceException3)
+
+    def test_can_be_raised_and_caught_as_the_broader_type(self):
+        try:
+            raise ReferenceRuntimeException3("runtime problem")
+        except ReferenceException3 as e:
+            assert isinstance(e, ReferenceRuntimeException3)

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -7,7 +7,9 @@ from csvpath.references.reference_3 import (
     Reference3,
     Regex3,
     Star3,
+    Variable3,
 )
+from csvpath.references.reference_exceptions_3 import ReferenceRuntimeException3
 from csvpath.references.reference_finder_3 import ReferenceFinder3
 from csvpath.references.reference_parser_3 import ReferenceParser3
 from csvpath.references.reference_results_3 import ReferenceResult3, ReferenceResults3
@@ -528,3 +530,70 @@ class TestResolveValue:
         finder = _dummy({"a": "1"})
         finder.set_variables({"b": "2"})
         assert finder._resolve_value(arg) == "1-2"
+
+    def test_bare_variable_resolves_to_its_raw_registered_value(self):
+        # added 2026-08-27 -- unlike the interpolation-part case above,
+        # a BARE Variable3 (not embedded in "{...}") returns the raw
+        # value, not a stringified one -- a direct function argument
+        # (e.g. :having(@id)) may need to stay whatever type it really
+        # is, not become text.
+        finder = _dummy({"n": 42})
+        assert finder._resolve_value(Variable3(name="n")) == 42
+
+    def test_bare_unregistered_variable_raises_runtime_exception(self):
+        with pytest.raises(ReferenceRuntimeException3):
+            _dummy()._resolve_value(Variable3(name="missing"))
+
+
+class TestBuildAndResolveArg:
+    # central, eager arg resolution (settled 2026-08-27, David: "central
+    # eager resolve of args is right, certainly for now, at least") --
+    # _build()/_build_chain() wrap ReferenceFunctionFactory.build()/
+    # build_chain(), resolving a Variable3/InterpolatedString3 arg in
+    # place so every other call site in every finder just reads .arg
+    # and gets a plain, already-resolved value.
+    def test_build_resolves_a_registered_variable_arg(self):
+        finder = _dummy({"id": "orders"})
+        call = FunctionCall3(name="having", arg=Variable3(name="id"))
+        built = finder._build(call)
+        assert built.arg == "orders"
+
+    def test_build_leaves_a_plain_arg_unchanged(self):
+        finder = _dummy()
+        call = FunctionCall3(name="having", arg="orders")
+        built = finder._build(call)
+        assert built.arg == "orders"
+
+    def test_build_raises_runtime_exception_for_unregistered_variable(self):
+        finder = _dummy()
+        call = FunctionCall3(name="having", arg=Variable3(name="id"))
+        with pytest.raises(ReferenceRuntimeException3):
+            finder._build(call)
+
+    def test_build_raises_runtime_exception_for_wrong_resolved_type(self):
+        # :having() takes (str,) -- a variable that resolves to an int
+        # passes check_valid()'s own structural check (Variable3 is
+        # unconditionally allowed there, regardless of ARG_TYPES) but
+        # fails here, once the real value is actually known.
+        finder = _dummy({"id": 5})
+        call = FunctionCall3(name="having", arg=Variable3(name="id"))
+        with pytest.raises(ReferenceRuntimeException3):
+            finder._build(call)
+
+    def test_build_chain_resolves_every_functions_own_arg(self):
+        finder = _dummy({"id": "orders"})
+        calls = [FunctionCall3(name="having", arg=Variable3(name="id"))]
+        built = finder._build_chain(calls)
+        assert built[0].arg == "orders"
+
+    def test_nested_function_arg_is_also_resolved(self):
+        # :errors(:idchain(@pattern))-style nesting -- ReferenceFunctionFactory.
+        # build() already recurses to compile the inner FunctionCall3
+        # into a real Function3 before the outer one is constructed;
+        # _resolve_arg() must recurse the same way to reach the INNER
+        # function's own arg, not just the outer one.
+        finder = _dummy({"pattern": "add[0]"})
+        inner = FunctionCall3(name="idchain", arg=Variable3(name="pattern"))
+        outer = FunctionCall3(name="errors", arg=inner)
+        built = finder._build(outer)
+        assert built.arg.arg == "add[0]"

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -83,11 +83,14 @@ def _write_archive_manifest_multi(archive, groups: dict) -> None:
 
 
 def _finder(
-    reference: str, archive: str, log_file: str | None = None
+    reference: str,
+    archive: str,
+    log_file: str | None = None,
+    variables: dict | None = None,
 ) -> ResultsReferenceFinder3:
     csvpaths = _FakeCsvPaths(archive, log_file=log_file)
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
-    return ResultsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+    return ResultsReferenceFinder3(csvpaths=csvpaths, ref=ref, variables=variables)
 
 
 @pytest.fixture
@@ -250,6 +253,18 @@ class TestHavingFiltersRunsByInstanceIdentity:
     ):
         results = _finder(
             "$acme.results.customers/2025:having(\"company_names\")", acme_archive
+        ).query()
+        assert results.uuids == ["run1-uuid"]
+
+    def test_having_accepts_a_registered_variable_as_its_argument(self, acme_archive):
+        # end-to-end proof of the central, eager @variable-argument
+        # resolution added 2026-08-27 -- real grammar parse through to a
+        # real registered function (:having(), ARG_TYPES = (str,)),
+        # same result as the literal-string version above.
+        results = _finder(
+            "$acme.results.customers/2025:last():having(@id)",
+            acme_archive,
+            variables={"id": "company_names"},
         ).query()
         assert results.uuids == ["run1-uuid"]
 


### PR DESCRIPTION
## Summary

Closes a deferred-work bucket-list item, surfaced while scoping the `:regex()` root_major design: `@variable` registration and `{...}` interpolation evaluation were built 2026-08-26, but a bare `@variable` used directly as some *other* function's own argument (e.g. `:having(@id)`, the motivating case for a future `:regex(@aregex)`) was not. No registered function's `ARG_TYPES` included `Variable3`, and nothing resolved a bare `Variable3` to its real value (only `Variable3` parts nested inside an `InterpolatedString3` were resolved).

## Two decisions settled first

- Reference-level `@variable`s (the existing simple, explicit `set_variable()`/`set_variables()` dict registration) must never be tied to a live running CsvPath instance's own runtime variables — even in the uncertain future case of v3 references being used as productions within csvpath statements, only copy-by-value, never a shared pointer.
- Central, eager resolution — resolve every function's own arg once, right after it's built, before any finder logic touches `.arg` — over resolving lazily at each of the many places a finder reads some function's `.arg`. "Certainly for now, at least."

## What was built

- **`ReferenceRuntimeException3`** — a subclass of `ReferenceException3`, for problems only detectable at resolve time (a missing variable, or one that resolved to the wrong type), not by `check_valid()`'s parse-time structural check. Mirrors the matching language's own static-vs-runtime split (`Args.validate()` → `ChildrenException`, `Args.matches()` → `MatchException`, `csvpath/matching/functions/args.py`) — without that split's `error_manager`/`do_i_raise()` collection machinery, which references v3 has never had and doesn't need here.
- **`Function3.check_valid()`** widened — any function with a non-empty `ARG_TYPES` also accepts a bare `Variable3`, unconditionally (reuses the existing `InterpolatedString3` widening's *shape*, not its `str`-gated condition, since a variable's resolved value could be any type).
- **`Function3.arg`** gained a setter, overwritten once during resolution.
- **`ReferenceFinder3._resolve_value()`** gained a bare-`Variable3` branch — returns the raw resolved value, not stringified (unlike the interpolation-part case, which always assembles a string).
- **`ReferenceFinder3._build()`/`_build_chain()`** (new) — wrap the factory's `build()`/`build_chain()`, then resolve the built function's own arg in place via a new `_resolve_arg()` helper, which recurses into nested function args and raises `ReferenceRuntimeException3` if a resolved value doesn't satisfy `ARG_TYPES` — the deferred check `check_valid()` couldn't do.
- **All 14 existing call sites**, across the base finder and all three concrete finders, now go through `_build()`/`_build_chain()` instead of calling the factory directly — a mechanical swap, verified behavior-neutral by the full suite staying green throughout. Three methods that used to be `@staticmethod`s became instance methods, since central resolution needs a finder's own registered variables.

**Deliberately not built:** wiring reference-level variables into a live CsvPath instance's own runtime variable store — explicitly ruled out, separate from and bigger than this work. `:regex()` itself remains unbuilt; this specifically unblocks `:regex(@aregex)`.

## Test plan

- [x] Widened `test_function_3.py` (`Variable3` accepted for str-typed and int-typed `ARG_TYPES`, still rejected for no-arg functions, new `arg` setter coverage).
- [x] New `test_reference_exceptions_3.py` (subclass relationship).
- [x] Widened `TestResolveValue` and new `TestBuildAndResolveArg` in `test_reference_finder_3.py`.
- [x] New end-to-end test in `test_results_reference_finder_3.py`: `$acme.results.customers/2025:last():having(@id)` against a real fixture, same result as the literal-string version.
- [x] `tests/references/` + `tests/csvpaths/references/`: 1517 passed.
- [x] Full local-backend suite: 3074/3074 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
