### PR TITLE
Implement :regex() at root_major

### DIFF
--- a/csvpath/references/csvpaths_reference_finder_3.py
+++ b/csvpath/references/csvpaths_reference_finder_3.py
@@ -119,6 +119,23 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
                 )
             return self._query_star_traversal(reference)
 
+        if isinstance(root_major, FunctionCall3):
+            # :regex() at root_major -- added 2026-08-27. Structurally
+            # identical to the Star3 case just above (every group is a
+            # candidate), just pre-filtered by pattern before
+            # _query_star_traversal() enumerates -- see its own
+            # name_filter docstring. No other function is legal here;
+            # the grammar itself is permissive (any function, see
+            # reference_grammar_3.py's own note) so this is a semantic
+            # check, not a grammar-level one.
+            if root_major.name != "regex":
+                raise ReferenceException3(
+                    f":{root_major.name}() is not a legal root_major "
+                    "function -- only :regex() is supported."
+                )
+            built = self._build(root_major)
+            return self._query_star_traversal(reference, name_filter=built.pattern)
+
         name_one = reference.name_one
         if name_one.name_two is not None:
             raise ReferenceException3(
@@ -246,9 +263,18 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             results=results, ambiguous_content_read=ambiguous_content_read
         )
 
-    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+    def _query_star_traversal(
+        self, reference: Reference3, name_filter: "str | None" = None
+    ) -> ReferenceResults3:
         """root_major == "*" -- query across every named-paths group,
-        not just one. Unlike FILES, csvpaths' version-selecting pointer
+        not just one. `name_filter` (added 2026-08-27, query()'s own
+        :regex()-at-root_major branch) restricts both enumeration loops
+        below (via ReferenceFinder3._matching_names()) to groups whose
+        own name matches the pattern -- "every group whose name matches
+        this pattern" is the SAME candidate-gathering '*' already does
+        here, just pre-filtered before enumeration, not a new traversal
+        mode. None (the default) means every group, the ordinary '*'
+        case, unchanged. Unlike FILES, csvpaths' version-selecting pointer
         and ':all()' both already live in name_one's own combined chain
         (see _resolve_versions) -- there is no separate name_three
         pointer slot to borrow the way FILES uses. Two semantics, each
@@ -393,7 +419,9 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
 
         if is_grouped:
             selected_versions = []
-            for name in self.csvpaths.paths_manager.named_paths_names:
+            for name in self._matching_names(
+                self.csvpaths.paths_manager.named_paths_names, name_filter
+            ):
                 manifest = _having_filtered(
                     self.csvpaths.paths_manager.get_manifest_for_name(name)
                 )
@@ -422,7 +450,9 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
             # needs a pointer to be meaningful, same as GROUP mode already
             # proved.
             pooled = []
-            for name in self.csvpaths.paths_manager.named_paths_names:
+            for name in self._matching_names(
+                self.csvpaths.paths_manager.named_paths_names, name_filter
+            ):
                 pooled.extend(
                     _having_filtered(
                         self.csvpaths.paths_manager.get_manifest_for_name(name)
@@ -605,10 +635,15 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
 
     def _group_manifest_entry(self, root_major, uuid: str) -> tuple:
         """returns (group_name, manifest_entry) for the version matching
-        uuid. When root_major is the '*' token (a '*' traversal result --
-        added 2026-08-18) the matched version could belong to any named-
-        paths group, so every group's own manifest is searched for the
-        matching uuid -- uuids are assumed globally unique, the same
+        uuid. When root_major spans potentially more than one group --
+        the '*' token, or a :regex() selector (added 2026-08-27, see
+        ReferenceFinder3._is_traversal_root()) -- the matched version
+        could belong to any named-paths group, so every group's own
+        manifest is searched for the matching uuid (searched by uuid,
+        not filtered by the regex pattern again -- a :regex() match
+        already narrowed which groups were candidates back in query(),
+        this just needs to find which ONE of them this particular uuid
+        came from) -- uuids are assumed globally unique, the same
         assumption _find_manifest_entry_by_uuid's every other call site
         already makes. Otherwise root_major is a literal group name --
         looked up directly, same as every call site used to do inline
@@ -617,7 +652,7 @@ class CsvpathsReferenceFinder3(ReferenceFinder3):
         RESULTS' potentially-large run history (RESULTS did not need an
         equivalent helper for this same reason -- see
         ResultsReferenceFinder3._extract_data's own comment on why)."""
-        if isinstance(root_major, Star3):
+        if self._is_traversal_root(root_major):
             for name in self.csvpaths.paths_manager.named_paths_names:
                 manifest = self.csvpaths.paths_manager.get_manifest_for_name(name)
                 entry = self._find_manifest_entry_by_uuid(manifest, uuid)

--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -134,6 +134,23 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 )
             return self._query_star_traversal(reference)
 
+        if isinstance(root_major, FunctionCall3):
+            # :regex() at root_major -- added 2026-08-27. Structurally
+            # identical to the Star3 case just above (every named-file
+            # is a candidate), just pre-filtered by pattern before
+            # _query_star_traversal() enumerates -- see its own
+            # name_filter docstring. No other function is legal here;
+            # the grammar itself is permissive (any function, see
+            # reference_grammar_3.py's own note) so this is a semantic
+            # check, not a grammar-level one.
+            if root_major.name != "regex":
+                raise ReferenceException3(
+                    f":{root_major.name}() is not a legal root_major "
+                    "function -- only :regex() is supported."
+                )
+            built = self._build(root_major)
+            return self._query_star_traversal(reference, name_filter=built.pattern)
+
         name_one = reference.name_one
         if (
             name_one.name_two is not None
@@ -533,9 +550,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
             ambiguous_content_read=has_manifest and len(selected_candidates) > 1,
         )
 
-    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+    def _query_star_traversal(
+        self, reference: Reference3, name_filter: "str | None" = None
+    ) -> ReferenceResults3:
         """root_major == "*" -- query across every named-file, not just
-        one. Four distinct semantics, corrected/extended 2026-08-12 to
+        one. `name_filter` (added 2026-08-27, query()'s own :regex()-at-
+        root_major branch) restricts every named_file_names enumeration
+        below (via ReferenceFinder3._matching_names()) to named-files
+        whose own name matches the pattern -- "every named-file whose
+        name matches this pattern" is the SAME candidate-gathering '*'
+        already does here, just pre-filtered before enumeration, not a
+        new traversal mode. None (the default) means every named-file,
+        the ordinary '*' case, unchanged. Four distinct semantics,
+        corrected/extended 2026-08-12 to
         match ResultsReferenceFinder3's own depth vocabulary exactly
         (David: keep functions meaning the same thing across datatypes):
 
@@ -618,7 +645,9 @@ class FilesReferenceFinder3(ReferenceFinder3):
                     "-- definition.json is not versioned, there is no "
                     "version to select."
                 )
-            names = self.csvpaths.file_manager.named_file_names
+            names = self._matching_names(
+                self.csvpaths.file_manager.named_file_names, name_filter
+            )
             if is_home:
                 names = [
                     name for name in names if self._candidates_for_name(name, [])
@@ -647,11 +676,15 @@ class FilesReferenceFinder3(ReferenceFinder3):
         partitioned = is_grouped or is_deep_grouped
         if is_grouped:
             candidates = []
-            for name in self.csvpaths.file_manager.named_file_names:
+            for name in self._matching_names(
+                self.csvpaths.file_manager.named_file_names, name_filter
+            ):
                 candidates.extend(self._candidates_for_name(name, [Star3()]))
         elif is_flattened or is_deep_grouped:
             candidates = []
-            for name in self.csvpaths.file_manager.named_file_names:
+            for name in self._matching_names(
+                self.csvpaths.file_manager.named_file_names, name_filter
+            ):
                 candidates.extend(self._all_candidates_for_name(name))
         elif is_home:
             # bare ':home()', nothing chained onto it -- the zero-level
@@ -673,7 +706,9 @@ class FilesReferenceFinder3(ReferenceFinder3):
                     "supported so far."
                 )
             candidates = []
-            for name in self.csvpaths.file_manager.named_file_names:
+            for name in self._matching_names(
+                self.csvpaths.file_manager.named_file_names, name_filter
+            ):
                 candidates.extend(self._candidates_for_name(name, []))
         else:
             if name_one.functions:
@@ -684,7 +719,9 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 )
             pattern = self._compile_path_pattern(name_one.path)
             candidates = []
-            for name in self.csvpaths.file_manager.named_file_names:
+            for name in self._matching_names(
+                self.csvpaths.file_manager.named_file_names, name_filter
+            ):
                 candidates.extend(self._candidates_for_name(name, pattern))
 
         name_three = reference.name_three

--- a/csvpath/references/functions/reference_function_factory_3.py
+++ b/csvpath/references/functions/reference_function_factory_3.py
@@ -26,6 +26,7 @@ class ReferenceFunctionFactory:
         from .selectors.index_3 import Index3
         from .selectors.last_3 import Last3
         from .selectors.name_3 import Name3
+        from .selectors.regex_3 import RegexSelector3
         from .selectors.to_3 import To3
 
         from .well_known_files.data_3 import Data3
@@ -151,6 +152,7 @@ class ReferenceFunctionFactory:
             Last3.NAME: Last3,
             Index3.NAME: Index3,
             Name3.NAME: Name3,
+            RegexSelector3.NAME: RegexSelector3,
             All3.NAME: All3,
             Flatten3.NAME: Flatten3,
             Groups3.NAME: Groups3,

--- a/csvpath/references/functions/selectors/regex_3.py
+++ b/csvpath/references/functions/selectors/regex_3.py
@@ -1,0 +1,92 @@
+import re
+
+from ...reference_3 import Reference3, Regex3
+from ...reference_exceptions_3 import ReferenceException3
+from ..function_3 import Function3
+
+
+class RegexSelector3(Function3):
+    #
+    # root_major-only selector -- added 2026-08-27 (deferred-work
+    # bucket-list entry, "grammar / argument-type gaps": "root_major
+    # does not accept a :regex(...) function"). Selects among distinct
+    # named-files/named-paths groups/named-results groups THEMSELVES by
+    # matching their own registered NAME against a pattern -- root_
+    # major's own job (which entities are we even talking about), not a
+    # path segment WITHIN one already-chosen entity the way Name3's own
+    # Regex3 support is. Motivating case (David, 2026-08-27): a crowded
+    # named-files/named-paths/named-results area -- "acme_orders",
+    # "acme_invoices", "acme_shipping", and the same again for another
+    # partner, e.g. "abba_invoices" -- is more manageable when a
+    # reference can target "/abba_.*/" vs "/acme_.*/" directly, instead
+    # of enumerating every exact name.
+    #
+    # Design settled 2026-08-27, before building (David):
+    # - Function-only, no bare "/pattern/" form at root_major -- see
+    #   reference_grammar_3.py's own note on why (consistent with the
+    #   grammar's existing invariant that REGEX only ever appears inside
+    #   an argument, never occupying a whole grammatical slot on its
+    #   own).
+    # - Symmetric across all three datatypes, not FILES-only -- the
+    #   crowded-namespace motivation applies identically to named-paths/
+    #   named-results groups.
+    # - Composes with '*' traversal machinery: "every named-file/group
+    #   whose name matches this pattern" is the SAME candidate-gathering
+    #   each finder's own _query_star_traversal()/_discover_run_homes()
+    #   already does for '*', just pre-filtered by the pattern before
+    #   enumeration -- not a new traversal mode. See each finder's own
+    #   query()/_query_star_traversal() for where that filter is
+    #   actually applied.
+    #
+    # ARG_TYPES accepts a plain str too, not just Regex3 -- unlike
+    # Name3 (where a plain str means "exact literal match", a different
+    # thing from its Regex3 case), :regex()'s whole point is pattern
+    # matching, so a plain str arg here IS the pattern, treated
+    # identically to a Regex3's own .pattern (this also makes
+    # :regex(@aregex) actually usable: a caller registering a variable
+    # via set_variable() most naturally hands over a plain Python
+    # string, not a v3-internal Regex3 instance -- see the "@variable as
+    # some other function's own direct argument" done-list entry).
+    #
+    # ROLE is CONTEXT_SETTER, not POINTER -- mirrors Having3 exactly:
+    # narrows the candidate NAME set without resolving to exactly one
+    # entity.
+    #
+    NAME = "regex"
+    SUMMARY = (
+        "Selects among distinct named-files/named-paths groups/named-"
+        "results groups by matching their own name against a pattern -- "
+        "root_major only."
+    )
+    ROLE = Function3.CONTEXT_SETTER
+    DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    ARG_TYPES = (str, Regex3)
+    ARG_REQUIRED = True
+    POSITIONS = {
+        Reference3.FILES: (Reference3.ROOT_MAJOR,),
+        Reference3.CSVPATHS: (Reference3.ROOT_MAJOR,),
+        Reference3.RESULTS: (Reference3.ROOT_MAJOR,),
+    }
+
+    def check_valid(self) -> None:
+        """same ARG_TYPES/ARG_REQUIRED check every function gets, plus
+        an eager regex-syntax check regardless of whether the arg is a
+        Regex3 or a plain str (both are real patterns here, unlike
+        Name3's own str-means-something-different case) -- fail at
+        build time, not later, deep inside name matching, the first
+        time a candidate name happens to be compared against it."""
+        super().check_valid()
+        pattern = self._arg.pattern if isinstance(self._arg, Regex3) else self._arg
+        if isinstance(pattern, str):
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                raise ReferenceException3(f":regex() pattern is invalid: {e}") from e
+
+    @property
+    def pattern(self) -> str:
+        """the raw regex pattern string, regardless of whether the arg
+        was written as a Regex3 (/pattern/) or a plain str
+        ("pattern"/@variable) -- callers (each finder's own query())
+        need this uniformly, without caring which form was used."""
+        return self._arg.pattern if isinstance(self._arg, Regex3) else self._arg

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -489,6 +489,7 @@ class Reference3:
     # CsvpathsReferenceFinder3._resolve_versions() had no such guard at
     # all, while query()'s name_three handling did).
     #
+    ROOT_MAJOR = "root_major"
     NAME_ONE = "name_one"
     NAME_TWO = "name_two"
     NAME_THREE = "name_three"
@@ -548,6 +549,18 @@ class Reference3:
                 "not '*' alone."
             )
             raise ReferenceException3(msg)
+
+        # root_major's own structural validation -- added 2026-08-27,
+        # alongside :regex() -- root_major is a FunctionCall3 only for
+        # that one function today (see reference_grammar_3.py's own
+        # note on why the grammar stays permissive here rather than
+        # baking ":regex()" in as its own production); ARG_REQUIRED/
+        # ARG_TYPES get checked the same way any other function's do.
+        # Semantic legality (IS ":regex()" -- as opposed to some other,
+        # not-legal-here function -- actually the one present) is a
+        # separate check, made by each finder's own query(), not here.
+        if isinstance(self._root_major, FunctionCall3):
+            self._root_major.check_valid()
 
         # validates any "{...}" interpolation nested anywhere in this
         # reference's functions -- see FunctionCall3.check_valid()/

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -559,6 +559,40 @@ class ReferenceFinder3(ABC):
             return re.search(expected.pattern, actual) is not None
         return actual == expected
 
+    @staticmethod
+    def _is_traversal_root(root_major) -> bool:
+        """true when root_major spans potentially more than one entity
+        -- either the '*' token, or a :regex() selector (added
+        2026-08-27) -- as opposed to a literal, single-entity
+        IDENTIFIER. Used wherever a finder needs to decide "could this
+        matched result have come from any of several named-files/
+        named-paths groups/named-results groups" (e.g.
+        CsvpathsReferenceFinder3._group_manifest_entry()), as distinct
+        from the narrower, Star3-ONLY Rule 1a/1b global-ledger checks
+        each finder's own query()/_extract_data() also makes --
+        :regex() never reaches those, it has no equivalent global-
+        ledger shortcut of its own (see each finder's own query())."""
+        return isinstance(root_major, Star3) or (
+            isinstance(root_major, FunctionCall3) and root_major.name == "regex"
+        )
+
+    @staticmethod
+    def _matching_names(names: list, name_filter: "str | None") -> list:
+        """`names`, filtered down to those matching `name_filter` (a
+        regex pattern string, re.search()'d -- not anchored, same
+        convention _segment_matches() already uses for Regex3
+        everywhere else), or `names` unchanged when `name_filter` is
+        None. Added 2026-08-27 for :regex() at root_major -- shared by
+        FilesReferenceFinder3's/CsvpathsReferenceFinder3's own
+        _query_star_traversal(), each of which enumerates its own
+        datatype's full name list at several points; ResultsReference
+        Finder3 threads the same filter through its own single shared
+        _discover_run_homes() instead, since it already had one funnel
+        point these two finders don't."""
+        if name_filter is None:
+            return names
+        return [n for n in names if re.search(name_filter, n)]
+
     def _resolve_value(self, value):
         """returns `value` unchanged if it is a plain literal (str, int,
         etc.); resolves it if it is a bare Variable3 (added 2026-08-27,

--- a/csvpath/references/reference_grammar_3.py
+++ b/csvpath/references/reference_grammar_3.py
@@ -75,6 +75,20 @@ from lark import Lark, Tree, UnexpectedInput
 #   unquoted catch-all argument token: every regex argument, grouped or
 #   not, goes through REGEX, so there is exactly one way to write one.
 #
+# - root_major also accepts a function (added 2026-08-27, for :regex()) --
+#   NOT a bare REGEX token directly at this position. This mirrors the
+#   grammar's existing invariant that REGEX only ever appears inside
+#   `arg` (an argument value), never occupying a whole grammatical slot
+#   on its own -- a bare "/pattern/" as root_major would be the one
+#   place that broke that rule. The grammar stays permissive here (any
+#   function, not specifically :regex()) the same way it already is
+#   everywhere else in this file -- which specific function names are
+#   legal at which position is a semantic check the finder/Reference3
+#   makes, not a grammar-level restriction (see e.g. name_one's own
+#   function-valued segments, validated by each finder's own recognized-
+#   shape checks, not baked into the grammar as separate productions per
+#   function name).
+#
 REFERENCE_GRAMMAR_3 = r"""
     ?start: reference
 
@@ -82,6 +96,7 @@ REFERENCE_GRAMMAR_3 = r"""
 
     root_major: STAR
               | IDENTIFIER
+              | function
 
     datatype: FILES
             | CSVPATHS

--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -195,6 +195,23 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 )
             return self._query_star_traversal(reference)
 
+        if isinstance(root_major, FunctionCall3):
+            # :regex() at root_major -- added 2026-08-27. Structurally
+            # identical to the Star3 case just above (every group is a
+            # candidate), just pre-filtered by pattern before
+            # _query_star_traversal() enumerates -- see its own
+            # name_filter docstring. No other function is legal here;
+            # the grammar itself is permissive (any function, see
+            # reference_grammar_3.py's own note) so this is a semantic
+            # check, not a grammar-level one.
+            if root_major.name != "regex":
+                raise ReferenceException3(
+                    f":{root_major.name}() is not a legal root_major "
+                    "function -- only :regex() is supported."
+                )
+            built = self._build(root_major)
+            return self._query_star_traversal(reference, name_filter=built.pattern)
+
         name_one = reference.name_one
         if name_one.name_two is not None:
             raise ReferenceException3(
@@ -554,7 +571,9 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             ambiguous_content_read=wants_full_content and len(selected_runs) > 1,
         )
 
-    def _query_star_traversal(self, reference: Reference3) -> ReferenceResults3:
+    def _query_star_traversal(
+        self, reference: Reference3, name_filter: str | None = None
+    ) -> ReferenceResults3:
         """root_major == "*" -- query across every named-results group,
         not just one. Mirrors query()'s own dispatch tree (bare
         function-only / prefix+':flatten()' / prefix+':all()' /
@@ -563,7 +582,14 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         _discover_run_homes(None), which keeps each pair's group name
         specifically for this) instead of one fixed home -- added
         2026-08-19, closing the "literal/'*' path narrowing" gap this
-        method used to reject outright. ':groups()' (any-depth GROUP)
+        method used to reject outright. `name_filter` (added 2026-08-27,
+        query()'s own :regex()-at-root_major branch) restricts every
+        _discover_run_homes(None) call below to groups whose own name
+        matches the pattern -- "every group whose name matches this
+        pattern" is the SAME candidate-gathering '*' already does here,
+        just pre-filtered before enumeration, not a new traversal mode.
+        None (the default) means every group, the ordinary '*' case,
+        unchanged. ':groups()' (any-depth GROUP)
         stays unsupported here, same as bare ':groups()' already was --
         no established per-GROUP-of-named-results-groups meaning exists
         for it yet, left for if/when a real use case asks. name_three
@@ -645,7 +671,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # docstring and normative_reference_examples.txt's "THE
                 # ':all()' MEANING COLLISION AT STAR TRAVERSAL" section.
                 partitioned = []
-                for rh, group in self._discover_run_homes(None):
+                for rh, group in self._discover_run_homes(None, name_filter):
                     home = self.csvpaths.results_manager.get_named_results_home(
                         group
                     )
@@ -670,7 +696,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # the _matches_prefix filter, not by discovery itself),
                 # so no separate any-depth gathering logic is needed
                 # here.
-                run_homes = [rh for rh, _ in self._discover_run_homes(None)]
+                run_homes = [rh for rh, _ in self._discover_run_homes(None, name_filter)]
             else:
                 # zero-level (direct children of each run's own group's
                 # home) only -- same restriction the literal-root
@@ -678,7 +704,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                 # settled 2026-08-10.
                 run_homes = [
                     rh
-                    for rh, group in self._discover_run_homes(None)
+                    for rh, group in self._discover_run_homes(None, name_filter)
                     if self._matches_prefix(
                         rh,
                         self.csvpaths.results_manager.get_named_results_home(group),
@@ -712,7 +738,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             pointer, _, _, having_call = self._star_run_selector_chain(calls)
             run_homes = [
                 rh
-                for rh, group in self._discover_run_homes(None)
+                for rh, group in self._discover_run_homes(None, name_filter)
                 if self._matches_prefix_at_least(
                     rh,
                     self.csvpaths.results_manager.get_named_results_home(group),
@@ -747,7 +773,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
             calls = list(name_one.functions)
             pointer, _, _, having_call = self._star_run_selector_chain(calls)
             partitioned = []
-            for rh, group in self._discover_run_homes(None):
+            for rh, group in self._discover_run_homes(None, name_filter):
                 home = self.csvpaths.results_manager.get_named_results_home(group)
                 if self._matches_prefix(rh, home, pattern):
                     partitioned.append(
@@ -789,7 +815,7 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         pointer, _, _, having_call = self._star_run_selector_chain(calls)
         run_homes = [
             rh
-            for rh, group in self._discover_run_homes(None)
+            for rh, group in self._discover_run_homes(None, name_filter)
             if self._matches_prefix(
                 rh, self.csvpaths.results_manager.get_named_results_home(group), pattern
             )
@@ -1284,7 +1310,9 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         path = Nos(instance_dir).join(accessor.arg)
         return cls._read_well_known_file(path)
 
-    def _discover_run_homes(self, root_major: str | None) -> list[tuple[str, str]]:
+    def _discover_run_homes(
+        self, root_major: str | None, name_filter: str | None = None
+    ) -> list[tuple[str, str]]:
         """every distinct, still-existing (run_home, named_paths_name)
         pair, read from the archive-root manifest.json -- see this
         module's own docstring for why this replaces directory-walking
@@ -1293,16 +1321,26 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         single-group case), or None to skip the filter entirely and
         discover across every group -- used by '*' traversal, which
         already has this same archive-wide ledger in hand for Rule
-        1a/1b, so no separate group-name enumeration is needed. Each
-        pair's own group name is kept (not just the run_home) so '*'
-        traversal can tell whether a given run is a direct child of
-        *its own* group's home -- needed once a plain bare pointer
-        means zero-level-only (settled 2026-08-10, see :flatten() for
-        the any-depth case) rather than "ignore depth entirely." Many
-        entries can share the same run_home (one entry per csvpath-
-        statement execution, several statements per run), so dedupe; a
-        stale entry (the run since deleted) is dropped via an
-        existence check."""
+        1a/1b, so no separate group-name enumeration is needed.
+        `name_filter` (added 2026-08-27, for :regex() at root_major) is
+        an independent, additional filter -- a regex pattern string
+        checked against each entry's own group name via re.search(),
+        same semantics ReferenceFinder3._segment_matches() already uses
+        for Regex3 everywhere else. Always called with root_major=None
+        alongside a real name_filter (a literal group name and a
+        pattern are mutually exclusive ways to pick which groups are in
+        play -- query() never combines them), but kept as two separate
+        parameters rather than one, since they mean genuinely different
+        things (exact identity vs. pattern match), not just to avoid
+        redundant plumbing. Each pair's own group name is kept (not
+        just the run_home) so '*' traversal can tell whether a given
+        run is a direct child of *its own* group's home -- needed once
+        a plain bare pointer means zero-level-only (settled 2026-08-10,
+        see :flatten() for the any-depth case) rather than "ignore
+        depth entirely." Many entries can share the same run_home (one
+        entry per csvpath-statement execution, several statements per
+        run), so dedupe; a stale entry (the run since deleted) is
+        dropped via an existence check."""
         archive = self.csvpaths.config.get(section="results", name="archive")
         manifest_path = Nos(archive).join("manifest.json")
         if not Nos(manifest_path).exists():
@@ -1314,6 +1352,8 @@ class ResultsReferenceFinder3(ReferenceFinder3):
         for entry in entries:
             group = entry.get("named_paths_name")
             if root_major is not None and group != root_major:
+                continue
+            if name_filter is not None and not re.search(name_filter, group or ""):
                 continue
             run_home = entry.get("run_home")
             if run_home and run_home not in seen:

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -287,45 +287,8 @@ a named worksheet across every named-file matched by `'*'`.
 
 ## Grammar / argument-type gaps (spec says it should work, code doesn't yet)
 
-- `root_major` does not accept a `:regex(...)` function — grammar only
-  defines `root_major: STAR | IDENTIFIER` (`reference_grammar_3.py`), no
-  function alternative at all, even though `creating references v3.txt`
-  (lines 79-80) says it should. No `:regex()` *function* exists anywhere in
-  v3 today, for any position (`Regex3` is a `/pattern/` *literal* type,
-  usable as some other function's argument value — a different thing).
-  Confirmed 2026-08-27, while building `:name(/regex/)` (see
-  `deferred_work_done_list.md`), that this is a genuinely different,
-  bigger question, not a small extension of that fix: a root_major
-  regex would select among *distinct named-files/groups themselves*
-  (root_major's own job), not a path segment *within* one already-
-  chosen entity, and would need real grammar changes plus a decision on
-  how it composes with `'*'` traversal's own existing semantics.
-
-  **Design settled 2026-08-27 (David), not yet built:**
-  - Function-only, no bare `/pattern/` form at `root_major` — consistent
-    with the grammar's existing invariant that `REGEX` only ever appears
-    inside `arg` (an argument value), never occupying a whole
-    grammatical slot on its own; `:regex(/pattern/)`/`:regex("pattern")`/
-    `:regex(@aregex)` are legal, a bare `/pattern/` directly as
-    `root_major` is not.
-  - Symmetric across all three datatypes (FILES/CSVPATHS/RESULTS), not
-    FILES-only — the crowded-namespace motivation (`acme_orders`/
-    `acme_invoices`/`abba_invoices`, disambiguating by partner-name
-    prefix) applies identically to named-paths/named-results groups.
-  - Composition with `'*'` traversal: a `:regex()` root_major is
-    structurally "every named-file/group whose name matches this
-    pattern" -- the same candidate-gathering `_query_star_traversal()`
-    already does for `'*'` (enumerating `named_file_names`/
-    `named_paths_names`/etc.), just pre-filtered by the pattern before
-    enumeration, not a new traversal mode.
-  - Real dependency, not an afterthought: `:regex(@aregex)` needs
-    `@variable` to work as `:regex()`'s own direct argument — **now
-    built**, see the entry immediately below and
-    `deferred_work_done_list.md`.
-  Still not built: the grammar change (`root_major` needs a function
-  alternative), the `Regex3`-producing `:regex()` function itself
-  (nothing like it exists anywhere in v3 yet), and the traversal-filter
-  threading through each finder's own name-enumeration call sites.
+- `root_major` accepting a `:regex(...)` function — **BUILT 2026-08-27**,
+  see `deferred_work_done_list.md`.
 - `@variable` (`Variable3`) registration and `{...}` interpolation
   evaluation are both **built 2026-08-26** — see `deferred_work_done_list.md`.
   `@variable` used as some OTHER function's *own direct argument* (e.g.

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,124 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `:regex()` at `root_major` — BUILT 2026-08-27
+
+From the "grammar / argument-type gaps" bucket-list entry: `root_major`
+only accepted `STAR`/`IDENTIFIER` -- no way to select among distinct
+named-files/named-paths groups/named-results groups by pattern, even
+though `creating references v3.txt` (lines 79-80) said it should exist.
+Motivating case (David): a crowded namespace -- "acme_orders"/
+"acme_invoices"/"acme_shipping" alongside another partner's
+"abba_invoices" -- is more manageable when a reference can target
+"/abba_.*/" vs "/acme_.*/" directly, instead of enumerating every exact
+name. Design settled 2026-08-27 before building (function-only, no bare
+`/pattern/` form; symmetric across all three datatypes; composes with
+`'*'` traversal as a pre-filter, not a new mode) -- see that design
+discussion, kept in full in the git history of this same entry's earlier
+bucket-list form. Depended on `@variable` working as a function's own
+direct argument (`:regex(@aregex)`), built the same day (see the entry
+below).
+
+**Built:**
+
+- **Grammar**: `root_major: STAR | IDENTIFIER | function`
+  (`reference_grammar_3.py`) -- deliberately permissive (any function,
+  not a `:regex()`-specific production), mirroring how the grammar
+  stays generic everywhere else and leaves "which function names are
+  actually legal here" to a semantic check. Confirmed no LALR conflict
+  (the grammar's own design note already required this) -- COLON
+  (function) vs IDENTIFIER vs STAR are lexically distinguishable with
+  zero lookahead. The transformer needed no changes at all: `root_major`
+  was already a pure passthrough (`def root_major(self, value): return
+  value`), so a `FunctionCall3` child (already built bottom-up by the
+  existing `function` rule) just flows through unchanged.
+- **`Reference3.check_valid()`** now also calls `.check_valid()` on
+  `root_major` when it is a `FunctionCall3` (mirroring the same call
+  already made for `name_one`/`name_three`'s own functions) -- recurses
+  into a nested `InterpolatedString3`, same structural check every other
+  function gets.
+- **`RegexSelector3`** (new, `functions/selectors/regex_3.py`) --
+  `NAME = "regex"`, `ROLE = CONTEXT_SETTER` (mirrors `Having3` exactly:
+  narrows the candidate NAME set without resolving to exactly one
+  entity), `DATATYPES`/`POSITIONS` cover all three datatypes at a new
+  `Reference3.ROOT_MAJOR` position constant (added alongside
+  `NAME_ONE`/`NAME_TWO`/`NAME_THREE`, purely for documentation/future
+  type-ahead purposes -- nothing calls `_check_position()` with it, same
+  as every other bare/structurally-recognized function in this
+  codebase). `ARG_TYPES = (str, Regex3)` -- unlike `Name3` (where a
+  plain `str` means "exact literal match", a different thing from its
+  `Regex3` case), `:regex()`'s whole point is pattern matching, so a
+  plain `str` arg here IS the pattern, treated identically to a
+  `Regex3`'s own `.pattern` -- this is also what makes `:regex(@aregex)`
+  actually usable, since a caller registering a variable via
+  `set_variable()` most naturally hands over a plain Python string, not
+  a v3-internal `Regex3` instance. `check_valid()` eagerly
+  `re.compile()`s the pattern regardless of which arg form was used
+  (mirrors `Name3`'s own eager regex-syntax check) -- fail at build
+  time, not later, deep inside name matching.
+- **Each finder's `query()`** gained a new `isinstance(root_major,
+  FunctionCall3)` branch (checked after the existing `Star3` branch,
+  before the literal-root path) -- semantically rejects any function
+  other than `:regex()` (`":{name}() is not a legal root_major function
+  -- only :regex() is supported"`), then `self._build(root_major)`
+  (resolving `@variable` for free, via the central-eager-resolution
+  mechanism built earlier the same day) and dispatches to
+  `_query_star_traversal(reference, name_filter=built.pattern)` --
+  structurally identical to the `Star3` case, just pre-filtered.
+- **`_query_star_traversal()` in all three finders** gained an optional
+  `name_filter: str | None = None` parameter, `None` meaning "every
+  name," the ordinary `'*'` case, completely unchanged. Each finder
+  threads it through differently, matching its own existing
+  architecture rather than forcing one shape onto all three:
+  - **RESULTS**: `_discover_run_homes()` already had ONE shared funnel
+    point for every one of `_query_star_traversal()`'s 6 internal call
+    sites -- widened its own signature to accept `name_filter` directly
+    (`re.search()`'d against each entry's own group name), single-point
+    change.
+  - **FILES**/**CSVPATHS**: no equivalent shared funnel existed (5 and 2
+    raw `named_file_names`/`named_paths_names` enumeration sites,
+    respectively) -- added a new shared `ReferenceFinder3._matching_
+    names(names, name_filter)` helper (filters a name list by
+    `re.search()`, or returns it unchanged when `name_filter` is `None`)
+    and swapped each raw enumeration site to call it.
+- **`ReferenceFinder3._is_traversal_root(root_major)`** (new, shared) --
+  true for `Star3` OR a `:regex()` `FunctionCall3`, as opposed to a
+  literal single-entity `IDENTIFIER`. Used by
+  `CsvpathsReferenceFinder3._group_manifest_entry()` (widened from an
+  `isinstance(root_major, Star3)` check) to decide "could this matched
+  uuid have come from any of several groups, search all of them" --
+  needed for field-accessor/`:manifest()` content resolution on a
+  `:regex()`-matched result to work at all. Confirmed by tracing
+  (not assumed) that this is the ONLY place across all three finders'
+  `_extract_data()` methods that actually needed widening -- every other
+  `isinstance(root_major, Star3)` check found (FILES/RESULTS' own Rule
+  1a/1b global-arrivals/archive-ledger disambiguation, both
+  `Star3`-only) is specifically about a global-ledger shortcut
+  `:regex()` never reaches (it has no equivalent global-ledger special
+  case of its own, unlike `'*'`) and already falls through correctly to
+  the ordinary per-entity handling beneath it when the check does not
+  match -- confirmed by reading what each one falls through to, not by
+  guessing. FILES has no `_group_manifest_entry()`-equivalent helper at
+  all (its own star traversal already unconditionally rejects
+  `:manifest()`/field-accessor combined with traversal outside the
+  `:home()`/`:definition()` exemptions built earlier the same day), so
+  needed no widening there either.
+
+Tests: widened `test_references_3_grammar.py` (positive cases for
+`:regex()` across all three datatypes including `@variable`, a negative
+case confirming a bare `/pattern/` still is NOT legal directly at
+`root_major`); widened `test_reference_3.py`'s `TestReference3` (a
+function-valued `root_major` passes `check_valid()`, and recursion into
+its own nested `InterpolatedString3` is proven); new
+`test_regex_selector_3.py` (metadata, both arg forms, eager invalid-
+pattern rejection); new `TestRegexRootMajor` end-to-end classes in all
+three finders' own test files (crowded-namespace filtering, exclusion,
+empty-match, wrong-function rejection, `@variable` form) plus a new
+regex-specific case in CSVPATHS' existing `TestGroupManifestEntry` and
+an end-to-end content-resolution test proving the whole chain composes.
+Full local-backend suite green (3108/3108, run twice); pre-existing
+SFTP/S3 env-dependent failures unrelated to this change.
+
 ## `@variable` as some other function's own direct argument — BUILT 2026-08-27
 
 From the "grammar / argument-type gaps" bucket-list entry: `@variable`

--- a/tests/references/functions/selectors/test_regex_selector_3.py
+++ b/tests/references/functions/selectors/test_regex_selector_3.py
@@ -1,0 +1,58 @@
+import pytest
+
+from csvpath.references.functions.selectors.regex_3 import RegexSelector3
+from csvpath.references.functions.function_3 import Function3
+from csvpath.references.reference_3 import Reference3, Regex3
+from csvpath.references.reference_exceptions_3 import ReferenceException3
+
+
+def test_metadata():
+    f = RegexSelector3(arg="acme_.*")
+    assert f.name == "regex"
+    assert f.ROLE == Function3.CONTEXT_SETTER
+    assert f.DATATYPES == (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
+    assert f.POSITIONS == {
+        Reference3.FILES: (Reference3.ROOT_MAJOR,),
+        Reference3.CSVPATHS: (Reference3.ROOT_MAJOR,),
+        Reference3.RESULTS: (Reference3.ROOT_MAJOR,),
+    }
+
+
+def test_no_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        RegexSelector3().check_valid()
+
+
+def test_str_arg_is_valid():
+    RegexSelector3(arg="acme_.*").check_valid()  # should not raise
+
+
+def test_regex3_arg_is_valid():
+    RegexSelector3(arg=Regex3(pattern="acme_.*")).check_valid()  # should not raise
+
+
+def test_non_str_non_regex_arg_is_rejected():
+    with pytest.raises(ReferenceException3):
+        RegexSelector3(arg=5).check_valid()
+
+
+def test_invalid_regex_pattern_raises_at_check_valid_time():
+    # fail fast at build time, same as Name3's own eager regex-syntax
+    # check -- not later, deep inside name matching.
+    with pytest.raises(ReferenceException3):
+        RegexSelector3(arg="(unclosed").check_valid()
+
+
+def test_invalid_regex3_pattern_raises_at_check_valid_time():
+    with pytest.raises(ReferenceException3):
+        RegexSelector3(arg=Regex3(pattern="(unclosed")).check_valid()
+
+
+class TestPattern:
+    # .pattern gives the raw pattern string uniformly, regardless of
+    # which arg form was used.
+    def test_pattern_from_a_plain_str_arg(self):
+        assert RegexSelector3(arg="acme_.*").pattern == "acme_.*"
+
+    def test_pattern_from_a_regex3_arg(self):
+        assert RegexSelector3(arg=Regex3(pattern="acme_.*")).pattern == "acme_.*"

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -127,6 +127,7 @@ def _finder(
     by_name: dict | None = None,
     definitions_by_name: dict | None = None,
     log_file: str | None = None,
+    variables: dict | None = None,
 ) -> CsvpathsReferenceFinder3:
     csvpaths = _FakeCsvPaths(
         _FakePathsManager(
@@ -140,7 +141,7 @@ def _finder(
         log_file=log_file,
     )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
-    return CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref)
+    return CsvpathsReferenceFinder3(csvpaths=csvpaths, ref=ref, variables=variables)
 
 
 class TestVersionPointer:
@@ -871,6 +872,23 @@ class TestGroupManifestEntry:
         assert name == "beta"
         assert entry["uuid"] == "b-v1"
 
+    def test_regex_root_major_finds_the_correct_group(self):
+        # added 2026-08-27 -- a :regex() root_major spans potentially
+        # more than one group too (ReferenceFinder3._is_traversal_root()),
+        # same reasoning as the '*' case above.
+        from csvpath.references.reference_3 import FunctionCall3
+
+        by_name = {
+            "acme_group": [{"group_file_path": "x", "uuid": "a-v1"}],
+            "abba_group": [{"group_file_path": "y", "uuid": "b-v1"}],
+        }
+        finder = _finder("$acme_group.csvpaths.:last()", by_name=by_name)
+        name, entry = finder._group_manifest_entry(
+            FunctionCall3(name="regex", arg="abba_.*"), "b-v1"
+        )
+        assert name == "abba_group"
+        assert entry["uuid"] == "b-v1"
+
     def test_star_root_major_with_unknown_uuid_gives_none_none(self):
         by_name = {"alpha": [{"group_file_path": "x", "uuid": "a-v1"}]}
         finder = _finder("$*.csvpaths.:last()", by_name=by_name)
@@ -1583,3 +1601,74 @@ class TestLog:
         # misleading here (there is no acme-specific log content).
         with pytest.raises(ReferenceException3):
             _finder("$acme.csvpaths.:log()", log_file="x.log").query()
+
+
+REGEX_BY_NAME = {
+    "acme_group": [
+        {
+            "group_file_path": "named_paths/acme_group/group.csvpath",
+            "uuid": "acme-v1",
+            "time": "2026-01-01T00:00:00+00:00",
+            "named_paths_identities": [],
+        }
+    ],
+    "abba_group": [
+        {
+            "group_file_path": "named_paths/abba_group/group.csvpath",
+            "uuid": "abba-v1",
+            "time": "2026-01-02T00:00:00+00:00",
+            "named_paths_identities": [],
+        }
+    ],
+}
+
+
+class TestRegexRootMajor:
+    # :regex() at root_major -- added 2026-08-27, the crowded-namespace
+    # motivating case (David): "acme_group"/"abba_group" are more
+    # manageable when a reference can target "/abba_.*/" directly.
+    # Reuses CsvpathsReferenceFinder3's own '*'-traversal machinery,
+    # just pre-filtered by pattern before it enumerates
+    # named_paths_names.
+    def test_regex_filters_to_matching_groups(self):
+        results = _finder(
+            "$:regex(/^abba_.*/).csvpaths.:last()", by_name=REGEX_BY_NAME
+        ).query()
+        assert results.uuids == ["abba-v1"]
+
+    def test_regex_excludes_non_matching_groups(self):
+        results = _finder(
+            "$:regex(/^abba_.*/).csvpaths.:last()", by_name=REGEX_BY_NAME
+        ).query()
+        assert "acme-v1" not in results.uuids
+
+    def test_regex_with_no_matches_gives_empty(self):
+        results = _finder(
+            "$:regex(/^zzz_.*/).csvpaths.:last()", by_name=REGEX_BY_NAME
+        ).query()
+        assert results.uuids == []
+
+    def test_wrong_root_major_function_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$:having("x").csvpaths.:last()', by_name=REGEX_BY_NAME
+            ).query()
+
+    def test_regex_accepts_a_registered_variable(self):
+        results = _finder(
+            "$:regex(@aregex).csvpaths.:last()",
+            by_name=REGEX_BY_NAME,
+            variables={"aregex": "^abba_.*"},
+        ).query()
+        assert results.uuids == ["abba-v1"]
+
+    def test_content_resolution_finds_the_correct_group(self):
+        # proves _group_manifest_entry()'s own widened multi-group
+        # search (see TestGroupManifestEntry above) composes correctly
+        # through a real query()+resolve() -- not just unit-tested in
+        # isolation.
+        results = _finder(
+            "$:regex(/^abba_.*/).csvpaths.:last():uuid()",
+            by_name=REGEX_BY_NAME,
+        ).resolve()
+        assert results.results[0].data == "abba-v1"

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -2321,3 +2321,79 @@ class TestLog:
             log_file=str(log_path),
         ).resolve()
         assert results.results[0].data == "line1\nline2\n"
+
+
+REGEX_ACME_HOME = "inputs/named_files/acme_orders"
+REGEX_ACME_MANIFEST = [
+    {
+        "file": "inputs/named_files/acme_orders/x.csv",
+        "file_home": "inputs/named_files/acme_orders",
+        "uuid": "u-acme-1",
+    },
+]
+REGEX_ABBA_HOME = "inputs/named_files/abba_invoices"
+REGEX_ABBA_MANIFEST = [
+    {
+        "file": "inputs/named_files/abba_invoices/y.csv",
+        "file_home": "inputs/named_files/abba_invoices",
+        "uuid": "u-abba-1",
+    },
+]
+REGEX_BY_NAME = {
+    "acme_orders": (REGEX_ACME_HOME, REGEX_ACME_MANIFEST),
+    "abba_invoices": (REGEX_ABBA_HOME, REGEX_ABBA_MANIFEST),
+}
+
+
+class TestRegexRootMajor:
+    # :regex() at root_major -- added 2026-08-27, the crowded-namespace
+    # motivating case (David): "acme_orders"/"acme_invoices"/
+    # "abba_invoices" are more manageable when a reference can target
+    # "/abba_.*/" directly, instead of enumerating every exact name.
+    # Reuses FilesReferenceFinder3's own '*'-traversal machinery, just
+    # pre-filtered by pattern before it enumerates named_file_names.
+    def test_regex_filters_to_matching_named_files(self):
+        results = _finder(
+            "$:regex(/^abba_.*/).files.:home()",
+            REGEX_ACME_HOME,
+            REGEX_ACME_MANIFEST,
+            by_name=REGEX_BY_NAME,
+        ).query()
+        assert results.files == [REGEX_ABBA_HOME]
+
+    def test_regex_excludes_non_matching_named_files(self):
+        results = _finder(
+            "$:regex(/^abba_.*/).files.:home()",
+            REGEX_ACME_HOME,
+            REGEX_ACME_MANIFEST,
+            by_name=REGEX_BY_NAME,
+        ).query()
+        assert REGEX_ACME_HOME not in results.files
+
+    def test_regex_with_no_matches_gives_empty(self):
+        results = _finder(
+            "$:regex(/^zzz_.*/).files.:home()",
+            REGEX_ACME_HOME,
+            REGEX_ACME_MANIFEST,
+            by_name=REGEX_BY_NAME,
+        ).query()
+        assert results.files == []
+
+    def test_wrong_root_major_function_is_rejected(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                '$:having("x").files.:home()',
+                REGEX_ACME_HOME,
+                REGEX_ACME_MANIFEST,
+                by_name=REGEX_BY_NAME,
+            ).query()
+
+    def test_regex_accepts_a_registered_variable(self):
+        results = _finder(
+            "$:regex(@aregex).files.:home()",
+            REGEX_ACME_HOME,
+            REGEX_ACME_MANIFEST,
+            by_name=REGEX_BY_NAME,
+            variables={"aregex": "^abba_.*"},
+        ).query()
+        assert results.files == [REGEX_ABBA_HOME]

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -346,6 +346,31 @@ class TestReference3:
         )
         r.check_valid()  # should not raise
 
+    def test_check_valid_accepts_a_function_valued_root_major(self):
+        # added 2026-08-27, for :regex() at root_major -- a plain,
+        # structurally-valid FunctionCall3 there should not raise.
+        r = Reference3(
+            root_major=FunctionCall3(name="regex", arg="acme_.*"),
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+        )
+        r.check_valid()  # should not raise
+
+    def test_check_valid_recurses_into_root_majors_own_function(self):
+        # root_major's own FunctionCall3.check_valid() gets called too
+        # (not just name_one/name_three's) -- proven here via a nested
+        # InterpolatedString3 containing an illegal POINTER-role
+        # function, the same recursion TestFunctionCall3's own
+        # equivalent test proves for an ordinary name_one segment.
+        bad = InterpolatedString3(parts=["x-", FunctionCall3(name="first")])
+        r = Reference3(
+            root_major=FunctionCall3(name="regex", arg=bad),
+            datatype=Reference3.FILES,
+            name_one=self._name_one("a"),
+        )
+        with pytest.raises(ReferenceException3):
+            r.check_valid()
+
     def test_check_valid_rejects_bare_trailing_star(self):
         # "*" alone: "any of the data that ___" with nothing to
         # complete it -- no name_three, no trailing function on

--- a/tests/references/test_references_3_grammar.py
+++ b/tests/references/test_references_3_grammar.py
@@ -71,6 +71,13 @@ POSITIVE_CASES = [
     '$acme.results.:name(/^(?:Mon|Tue)day$/)/2025:first().invoices',
     '$acme.results.:name(/^(Mon|Tue)day$/)/2025:first().invoices',
     '$acme.results.:name(/contains"quote/)/2025:first().invoices',
+    # :regex() at root_major (added 2026-08-27) -- a function, not just
+    # STAR/IDENTIFIER, symmetric across all three datatypes.
+    '$:regex(/^acme_.*/).files.:all()',
+    '$:regex("acme_.*").files.:all()',
+    '$:regex(@aregex).files.:all()',
+    '$:regex(/^acme_.*/).csvpaths.:last()',
+    '$:regex(/^acme_.*/).results.:last()',
 ]
 
 NEGATIVE_CASES = [
@@ -83,6 +90,11 @@ NEGATIVE_CASES = [
     '$acme.files.:name("x".:data()',  # unclosed function paren
     '$acme.files.:last.:data()',  # function missing parens entirely
     '$acme.files.:().:data()',  # empty function name
+    # a bare "/pattern/" is not legal directly at root_major (added
+    # 2026-08-27) -- only a function (":regex(/pattern/)") is, per the
+    # grammar's existing invariant that REGEX only ever appears inside
+    # an argument, never occupying a whole grammatical slot on its own.
+    '$/^acme_.*/.files.:all()',
 ]
 
 

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -3025,3 +3025,47 @@ class TestLog:
             "$*.results.:log()", acme_archive, log_file=str(log_path)
         ).resolve()
         assert results.results[0].data == "line1\nline2\n"
+
+
+class TestRegexRootMajor:
+    # :regex() at root_major -- added 2026-08-27, the crowded-namespace
+    # motivating case (David): "acme_group"/"abba_group" are more
+    # manageable when a reference can target "/abba_.*/" directly.
+    # Reuses ResultsReferenceFinder3's own '*'-traversal machinery, just
+    # pre-filtered by pattern before _discover_run_homes() enumerates.
+    @pytest.fixture
+    def regex_archive(self, tmp_path):
+        acme_run = _make_run(
+            tmp_path / "acme_group", "2026-01-01_00-00-00", "acme-run-uuid", {}
+        )
+        abba_run = _make_run(
+            tmp_path / "abba_group", "2026-01-02_00-00-00", "abba-run-uuid", {}
+        )
+        _write_archive_manifest_multi(
+            tmp_path, {"acme_group": [acme_run], "abba_group": [abba_run]}
+        )
+        return str(tmp_path)
+
+    def test_regex_filters_to_matching_groups(self, regex_archive):
+        results = _finder("$:regex(/^abba_.*/).results.:last()", regex_archive).query()
+        assert results.uuids == ["abba-run-uuid"]
+
+    def test_regex_excludes_non_matching_groups(self, regex_archive):
+        results = _finder("$:regex(/^abba_.*/).results.:last()", regex_archive).query()
+        assert "acme-run-uuid" not in results.uuids
+
+    def test_regex_with_no_matches_gives_empty(self, regex_archive):
+        results = _finder("$:regex(/^zzz_.*/).results.:last()", regex_archive).query()
+        assert results.uuids == []
+
+    def test_wrong_root_major_function_is_rejected(self, regex_archive):
+        with pytest.raises(ReferenceException3):
+            _finder('$:having("x").results.:last()', regex_archive).query()
+
+    def test_regex_accepts_a_registered_variable(self, regex_archive):
+        results = _finder(
+            "$:regex(@aregex).results.:last()",
+            regex_archive,
+            variables={"aregex": "^abba_.*"},
+        ).query()
+        assert results.uuids == ["abba-run-uuid"]


### PR DESCRIPTION
## Summary

Closes a deferred-work bucket-list item: `root_major` only accepted `STAR`/`IDENTIFIER`, with no way to select among distinct named-files/named-paths groups/named-results groups by pattern. Motivating case: a crowded namespace -- `acme_orders`/`acme_invoices`/`acme_shipping` alongside another partner's `abba_invoices` -- is more manageable when a reference can target `/abba_.*/` vs `/acme_.*/` directly, instead of enumerating every exact name.

**Design settled before building:** function-only, no bare `/pattern/` form at `root_major` (consistent with the grammar's existing invariant that `REGEX` only ever appears inside an argument); symmetric across all three datatypes; composes with `'*'` traversal as a pre-filter on the same candidate-gathering machinery, not a new mode. Depended on `@variable` working as a function's own direct argument (built earlier today, #268) -- `:regex(@aregex)` is a first real consumer.

## What was built

- **Grammar**: `root_major: STAR | IDENTIFIER | function`. Deliberately permissive (any function, not a `:regex()`-specific production) and needed no transformer changes -- `root_major` was already a pure passthrough.
- **`Reference3.check_valid()`** now also validates `root_major` when it's a function call, mirroring `name_one`/`name_three`.
- **`RegexSelector3`** -- a new `CONTEXT_SETTER` function (mirrors `Having3`), `ARG_TYPES = (str, Regex3)` so both `/pattern/` and a plain string (and therefore a variable holding one) work identically, with an eager `re.compile()` check at build time.
- **Each finder's `query()`** gained an `isinstance(root_major, FunctionCall3)` branch: rejects any function other than `:regex()`, otherwise resolves it (via the central-eager-resolution mechanism from #268, so `@variable` works for free) and dispatches to `_query_star_traversal()` with the pattern threaded through as a name filter.
- **`_query_star_traversal()` in all three finders** gained an optional `name_filter` parameter. RESULTS already had one shared enumeration funnel (`_discover_run_homes()`) to widen; FILES and CSVPATHS got a new shared `ReferenceFinder3._matching_names()` helper, applied at each of their own raw enumeration sites.
- **`ReferenceFinder3._is_traversal_root()`** -- a small shared helper recognizing `Star3` or a `:regex()` call as "could span more than one entity" -- used to widen `CsvpathsReferenceFinder3._group_manifest_entry()`'s own group search, the one place across all three finders' content-resolution code that actually needed it (confirmed by tracing every other `root_major`/`Star3` check, not assumed -- the rest are global-ledger-only shortcuts `:regex()` never reaches and already fall through correctly).

## Test plan

- [x] Widened `test_references_3_grammar.py` (positive cases for `:regex()` across all three datatypes including `@variable`, a negative case confirming a bare `/pattern/` still isn't legal directly at `root_major`).
- [x] Widened `test_reference_3.py`'s `TestReference3` (function-valued `root_major` passes `check_valid()`, recursion into a nested `InterpolatedString3` proven).
- [x] New `test_regex_selector_3.py` (metadata, both arg forms, eager invalid-pattern rejection).
- [x] New `TestRegexRootMajor` end-to-end classes in all three finders' own test files (crowded-namespace filtering, exclusion, empty-match, wrong-function rejection, `@variable` form), plus a regex-specific case in CSVPATHS' existing `TestGroupManifestEntry` and an end-to-end content-resolution test.
- [x] `tests/references/` + `tests/csvpaths/references/`: 1551 passed.
- [x] Full local-backend suite: 3108/3108 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
