### PR TITLE
Replace resolve_kind's hardcoded name tuples with declarative metadata_kind()

### DIFF
--- a/csvpath/references/function_describer_3.py
+++ b/csvpath/references/function_describer_3.py
@@ -68,6 +68,9 @@ class Function3Describer:
             rows.append(["Ledger fallback key", ledger_key])
         if function_cls.BARE_SOURCE:
             rows.append(["Bare source", function_cls.BARE_SOURCE])
+        kind = function_cls.metadata_kind()
+        if kind:
+            rows.append(["Resolves as", kind])
         lines.append(tabulate(rows, tablefmt="pipe"))
         return "\n".join(lines)
 

--- a/csvpath/references/functions/filters/idchain_3.py
+++ b/csvpath/references/functions/filters/idchain_3.py
@@ -55,6 +55,18 @@ class Idchain3(Function3):
         "nested inside :errors()."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- added 2026-08-28. Idchain3 has no
+    # SOURCE of its own (it never reads a manifest/definition key by a
+    # dotted path the way an ordinary field accessor does), so nothing
+    # would otherwise mark a reference containing it METADATA_FIELD --
+    # but per the "position decides meaning" rule above, being NESTED
+    # as :errors()'s own argument is exactly what narrows that whole-
+    # resource read down to a field-level one. This is the one function
+    # in the registry that needed an explicit override for this reason
+    # specifically (every other METADATA_FIELD function gets there for
+    # free via its own SOURCE) -- see Function3.RESOLVES_AS's own
+    # docstring for the full accounting.
+    RESOLVES_AS = Reference3.METADATA_FIELD
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = (str, Regex3, PredicateFunction3)
     ARG_REQUIRED = True

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ..reference_3 import InterpolatedString3, Variable3
+from ..reference_3 import InterpolatedString3, Reference3, Variable3
 from ..reference_exceptions_3 import ReferenceException3
 
 
@@ -116,6 +116,39 @@ class Function3:
     # docstring for the full worked example.
     #
     BARE_SOURCE: str = None
+
+    #
+    # explicit override for metadata_kind()/Reference3.resolve_kind() --
+    # added 2026-08-28, replacing the old _METADATA_FILE_FUNCTIONS/
+    # _METADATA_FIELD_FUNCTIONS hardcoded name tuples (reference_3.py's
+    # own long-standing "both lists will be replaced by real per-
+    # function trait lookups once Function3 exists" comment, never
+    # acted on until now). Confirmed by direct inspection, not assumed,
+    # before designing this: _METADATA_FIELD_FUNCTIONS' 84 names were
+    # EXACTLY {every function with SOURCE not in (None, "clock")} (83
+    # names) PLUS "idchain" (1 name, the sole exception -- see Idchain3's
+    # own RESOLVES_AS for why). So 83 of 84 functions never needed an
+    # explicit entry in either list at all -- their own SOURCE
+    # declaration (already required for KEY-lookup to work) already
+    # implies METADATA_FIELD for free via metadata_kind()'s own default
+    # rule below. RESOLVES_AS only needs setting on the genuine
+    # exceptions: the ten functions/well_known_files/ classes (a whole-
+    # resource read has no SOURCE/KEY of its own at all, so nothing
+    # would otherwise mark them METADATA_FILE), and Idchain3 (which
+    # narrows its PARENT's resolution when nested, despite having no
+    # SOURCE of its own either). Leave None (the default) for every
+    # other function -- it needs no override, its own SOURCE (or lack
+    # of one) already says everything metadata_kind() needs to know.
+    # Uses Reference3.METADATA_FILE/METADATA_FIELD's own constants
+    # directly (not a separate boolean/enum) specifically so this is
+    # self-documenting on sight -- reading Errors3.RESOLVES_AS tells you
+    # exactly what Reference3.resolve_kind() will classify a bare
+    # :errors() reference as, using the identical vocabulary, not a
+    # second name to learn. See metadata_kind() below for how this and
+    # SOURCE combine, and Function3Describer/describe() for how this
+    # surfaces in a function's own self-documentation.
+    #
+    RESOLVES_AS: "str | None" = None
 
     #
     # declares which conceptual "family" this VALUE-role function's own
@@ -244,17 +277,50 @@ class Function3:
         if isinstance(self._arg, (Function3, InterpolatedString3)):
             self._arg.check_valid()
 
+    @classmethod
+    def metadata_kind(cls) -> "str | None":
+        """Reference3.METADATA_FILE/METADATA_FIELD this function
+        resolves as when it is a TERMINAL function in a reference's own
+        chain, or None for an ordinary FIRST_PARTY function (e.g. a
+        pointer/path-building function, or a SOURCE == "clock" value
+        function used bare/in "{...}" interpolation). Added 2026-08-28
+        as the single shared source of truth both Reference3.
+        resolve_kind() (chain-walking logic) and this class's own
+        describe()/Function3Describer (self-documentation) read --
+        computed once, here, rather than duplicated in both places.
+
+        RESOLVES_AS is an explicit override, needed by only ~11
+        functions today (see its own docstring for exactly which and
+        why); every other function's SOURCE declaration already implies
+        METADATA_FIELD for free, at zero extra maintenance cost, since
+        SOURCE was always required anyway for that function's own KEY-
+        lookup to work. SOURCE == "clock" is deliberately excluded --
+        a bare value with no entity/manifest context at all (e.g.
+        :year()) is neither kind of metadata resolution."""
+        if cls.RESOLVES_AS is not None:
+            return cls.RESOLVES_AS
+        if cls.SOURCE not in (None, "clock"):
+            return Reference3.METADATA_FIELD
+        return None
+
     def describe(self) -> dict:
         """machine-actionable self-description -- also human-readable
         via SUMMARY. this is what a future type-ahead layer's registry
         query is meant to read (see references_notes/
         autocomplete_prototype.py's registry shape: name/summary/
-        datatypes)."""
+        datatypes). "resolves_as" (added 2026-08-28) surfaces
+        metadata_kind()'s own answer directly -- an AI agent (or any
+        other reader) inspecting this function's self-description can
+        see exactly what it contributes to a reference's own
+        Reference3.resolve_kind() classification, without needing to
+        already understand the RESOLVES_AS/SOURCE mechanics behind
+        metadata_kind() itself."""
         return {
             "name": self.NAME,
             "summary": self.SUMMARY,
             "role": self.ROLE,
             "datatypes": self.DATATYPES,
+            "resolves_as": self.metadata_kind(),
         }
 
     def __eq__(self, other) -> bool:

--- a/csvpath/references/functions/well_known_files/data_3.py
+++ b/csvpath/references/functions/well_known_files/data_3.py
@@ -18,6 +18,10 @@ class Data3(Function3):
         "lines matched (the file was never written)."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/definition_3.py
+++ b/csvpath/references/functions/well_known_files/definition_3.py
@@ -36,6 +36,10 @@ class Definition3(Function3):
         "explicitly configured (no definition.json written yet)."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/errors_3.py
+++ b/csvpath/references/functions/well_known_files/errors_3.py
@@ -48,6 +48,10 @@ class Errors3(Function3):
         "filtered to entries matching a nested :idchain(...) argument."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = (Idchain3,)
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/file_3.py
+++ b/csvpath/references/functions/well_known_files/file_3.py
@@ -21,6 +21,10 @@ class File3(Function3):
         "None if no such file was written."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = (str,)
     ARG_REQUIRED = True

--- a/csvpath/references/functions/well_known_files/log_3.py
+++ b/csvpath/references/functions/well_known_files/log_3.py
@@ -23,6 +23,10 @@ class Log3(Function3):
         "only, root_major must be '*'; not tied to any datatype/entity."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = (int,)
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/manifest_3.py
+++ b/csvpath/references/functions/well_known_files/manifest_3.py
@@ -38,6 +38,10 @@ class Manifest3(Function3):
         "path/version narrowing."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.FILES, Reference3.CSVPATHS, Reference3.RESULTS)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/meta_3.py
+++ b/csvpath/references/functions/well_known_files/meta_3.py
@@ -17,6 +17,10 @@ class Meta3(Function3):
         "and runtime data."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/printouts_3.py
+++ b/csvpath/references/functions/well_known_files/printouts_3.py
@@ -21,6 +21,10 @@ class Printouts3(Function3):
         "written)."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/unmatched_3.py
+++ b/csvpath/references/functions/well_known_files/unmatched_3.py
@@ -19,6 +19,10 @@ class Unmatched3(Function3):
         "written)."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/functions/well_known_files/vars_3.py
+++ b/csvpath/references/functions/well_known_files/vars_3.py
@@ -17,6 +17,10 @@ class Vars3(Function3):
         "variables that csvpath statement's execution captured."
     )
     ROLE = Function3.VALUE
+    # metadata_kind() override -- a whole-resource read, not a
+    # single field, see Function3.RESOLVES_AS's own docstring for
+    # why this class needs one (added 2026-08-28).
+    RESOLVES_AS = Reference3.METADATA_FILE
     DATATYPES = (Reference3.RESULTS,)
     ARG_TYPES = ()
     ARG_REQUIRED = False

--- a/csvpath/references/reference_3.py
+++ b/csvpath/references/reference_3.py
@@ -317,12 +317,6 @@ class NameThree3:
 
 
 #
-# PLACEHOLDER pending the real function registry (see "requirements for
-# functions.txt" -- functions are looked up/validated at runtime by a
-# registry that does not exist yet). Once it does, this belongs on
-# Function3 itself as self-description metadata, not here as bare name
-# lists.
-#
 # per "creating references v3.txt"'s "Query vs. Resolve" section, a
 # reference resolves to exactly one of three things:
 #   - first-party data: the actual underlying bytes/content, when no
@@ -337,111 +331,17 @@ class NameThree3:
 #     file rather than the file as a whole (e.g.
 #     :errors(:idchain("add[0]string[2]"))).
 #
-# these two lists are deliberately narrow placeholders, not a general
-# rule -- e.g. _METADATA_FIELD_FUNCTIONS is NOT "any nested function
-# arg": name_one already nests pointers inside functions all the time
-# for ordinary version/range selection (:from(:index(0)) is still
-# picking a file/version, not extracting a value). both lists will be
-# replaced by real per-function trait lookups once Function3 exists.
+# WAS two hardcoded name-string tuples here (_METADATA_FILE_FUNCTIONS/
+# _METADATA_FIELD_FUNCTIONS) -- replaced 2026-08-28 by
+# Function3.metadata_kind() (see that classmethod's own docstring, and
+# Function3.RESOLVES_AS), a declarative per-function trait lookup, the
+# real fix this file's own old placeholder comment had been pointing at
+# since Function3 was first built ("both lists will be replaced by real
+# per-function trait lookups once Function3 exists" -- it existed, the
+# replacement had just never been done). Confirmed the two mechanisms
+# agree on every one of the 124 functions registered at the time of the
+# switch before removing the tuples, not assumed.
 #
-_METADATA_FILE_FUNCTIONS = (
-    "errors",
-    "vars",
-    "meta",
-    "data",
-    "unmatched",
-    "printouts",
-    "file",
-    "definition",
-    "manifest",
-    "log",
-)
-_METADATA_FIELD_FUNCTIONS = (
-    "idchain",
-    "uuid",
-    "template",
-    "time",
-    "fingerprint",
-    "file_home",
-    "group_home",
-    "run_home",
-    "instance_home",
-    "host",
-    "origin",
-    "mark",
-    "named_paths_identities",
-    "named_paths_count",
-    "on_arrival",
-    "sources",
-    "scripts",
-    "webhooks",
-    "transfers",
-    "destinations",
-    "run_uuid",
-    "serial",
-    "valid",
-    "completed",
-    "files_complete",
-    "named_file_name",
-    "named_file_home",
-    "named_results_name",
-    "named_paths_name",
-    "status",
-    "method",
-    "hostname",
-    "username",
-    "time_completed",
-    "manifest_path",
-    "identity",
-    "actual_data_file",
-    "origin_data_file",
-    "file_fingerprints",
-    "source_mode_preceding",
-    "preceding_instance_identity",
-    "type",
-    "reference",
-    "file_path",
-    "archive",
-    "group_file",
-    "named_paths",
-    "error_count",
-    "named_paths_uuid",
-    "named_file_uuid",
-    "named_file_path",
-    "named_file_size",
-    "named_file_last_change",
-    "named_file_fingerprint",
-    "named_paths_fingerprint",
-    "run_dir",
-    "instance_index",
-    "named_paths_group",
-    "run_method",
-    "file_manifest",
-    "group_manifest",
-    "archive_path",
-    "named_files_root",
-    "named_paths_root",
-    "source_address",
-    "source_port",
-    "source_username",
-    "source_password",
-    "destination_address",
-    "destination_port",
-    "destination_username",
-    "destination_password",
-    "transfer_on_complete_all",
-    "transfer_on_complete_valid",
-    "transfer_on_complete_invalid",
-    "transfer_on_complete_error",
-    "script_on_complete_all",
-    "script_on_complete_valid",
-    "script_on_complete_invalid",
-    "script_on_complete_error",
-    "webhooks_on_complete_all",
-    "webhooks_on_complete_valid",
-    "webhooks_on_complete_invalid",
-    "webhooks_on_complete_error",
-)
 
 
 class Reference3:
@@ -627,23 +527,52 @@ class Reference3:
         -- FIRST_PARTY (the underlying bytes/content, the default),
         METADATA_FILE (a whole well-known/named file), or
         METADATA_FIELD (one value drilled out of such a file). computed
-        from terminal_functions (below). Safe to widen this
-        way -- an ordinary path-matching function like :name("...")
-        never appears in _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_
-        FUNCTIONS, so including path segments here only lets the real
+        from terminal_functions (below), reading each terminal
+        function's own registered Function3.metadata_kind() (added
+        2026-08-28, replacing the old hardcoded name-tuple dispatch --
+        see this module's own comment a few lines above class
+        Reference3). Safe to walk every path segment this way -- an
+        ordinary path-matching function like :name("...") has no
+        RESOLVES_AS override and no SOURCE, so metadata_kind() returns
+        None for it; including path segments here only lets the real
         metadata functions be seen, it does not change what gets
-        flagged. see the _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_
-        FUNCTIONS placeholder comment above -- both lists are stand-ins
-        for traits the future function registry will own."""
+        flagged.
+
+        METADATA_FIELD is checked first, and can come from ANYWHERE in
+        a terminal function's own nested-arg chain, not just the
+        terminal function itself -- e.g. :errors(:idchain(...)):
+        :errors() itself is METADATA_FILE on its own, but :idchain()
+        nested inside it is METADATA_FIELD, and that nested reading
+        wins (mirrors FunctionCall3.contains_function_named()'s own
+        one-level-of-FunctionCall3-nesting walk, the same shape the old
+        tuple-based check used via that same method). METADATA_FILE, by
+        contrast, only ever looks at each terminal function directly --
+        a metadata-FILE function nested inside another call is not a
+        real shape anything currently produces (nothing takes a whole-
+        resource function as its own argument), so no equivalent nested
+        walk is needed for it."""
+        # local import: the function registry lives in functions/,
+        # which already depends on this module (e.g. these very
+        # datatype/position constants) -- importing it back at module
+        # level here would be circular. deferred import breaks the
+        # cycle at exactly this one, narrow, unavoidable point (same
+        # reasoning as InterpolatedString3.check_valid()'s own deferred
+        # import above).
+        from .functions.reference_function_factory_3 import ReferenceFunctionFactory
+
+        def _kind_of(call: FunctionCall3) -> "str | None":
+            function_cls = ReferenceFunctionFactory.get_registered_class(call.name)
+            return function_cls.metadata_kind() if function_cls is not None else None
+
         terminal_functions = self.terminal_functions
         for f in terminal_functions:
-            if any(
-                f.contains_function_named(name)
-                for name in _METADATA_FIELD_FUNCTIONS
-            ):
-                return Reference3.METADATA_FIELD
+            call = f
+            while call is not None:
+                if _kind_of(call) == Reference3.METADATA_FIELD:
+                    return Reference3.METADATA_FIELD
+                call = call.arg if isinstance(call.arg, FunctionCall3) else None
         for f in terminal_functions:
-            if f.name in _METADATA_FILE_FUNCTIONS:
+            if _kind_of(f) == Reference3.METADATA_FILE:
                 return Reference3.METADATA_FILE
         return Reference3.FIRST_PARTY
 

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -48,53 +48,7 @@ candidates for that re-audit, all still unconditional/immediate raises in
   same "was a pointer actually applied within each partition" reasoning
   the literal-root fix used, not a blind port.
 
-## `resolve_kind`'s hardcoded name-tuple dispatch — needs examination for clarity/impact before deciding
-
-Found 2026-08-22 while checking whether the compendium's old §6 ("Known
-gaps") still had anything current in it. `Reference3.resolve_kind` (`reference_3.py`)
-dispatches `METADATA_FILE`/`METADATA_FIELD` classification off two hardcoded
-name-string tuples, `_METADATA_FILE_FUNCTIONS`/`_METADATA_FIELD_FUNCTIONS`
-(now over 60 names combined, after several rounds of new field accessors
-each needing their own name added by hand) — confirmed every single name in
-both tuples *is* backed by a real, registered `Function3` today. So nothing
-is factually broken, but the tuples have kept growing by hand with every
-new batch of field accessors — a maintenance cost, and exactly the kind of
-thing a declarative check would eliminate.
-
-But the code comment sitting directly above those two tuples says: "both
-lists will be replaced by real per-function trait lookups once `Function3`
-exists." `Function3` (with `ROLE`/`SOURCE`) now fully exists — that refactor
-was always the intended end state, and it appears to have never happened.
-`resolve_kind` still dispatches off two hardcoded name lists instead of a
-declarative check on the function classes themselves (e.g. `SOURCE is not
-None`, or similar). This is the same *kind* of architectural debt as the
-`SELECTOR_WHEN_ARGUED` idea already on this list (dual selector/value-
-accessor behavior), but it is a distinct mechanism — that entry is about
-declaring dual selector/value behavior; this one is about *how function
-category is recognized at all* — and isn't covered by that entry.
-
-**David, 2026-08-22: not yet clear on the meaning/impact of this one** —
-needs a real look (what would break or simplify if `resolve_kind` were
-switched to a declarative check, whether the two tuples could shrink to
-one shared mechanism, whether this connects to the still-unrecognized
-"file/well-known-file accessor" category from the four-function-types
-discussion) before deciding whether/how to act on it. Flagging for
-clarity, not yet a committed-to fix. Still true as of 2026-08-26 — every
-new field-accessor batch since has kept adding to the tuples by hand
-rather than resolving this.
-
-**A precedent for exactly this kind of fix already exists in the codebase**
-(found while scanning the old compendium copy before it was deleted):
-`ReferenceFinder3._check_position()` replaced a near-identical class of
-problem — scattered, hand-written, per-finder "is this recognized" guards
-that silently no-opped on anything genuinely unrecognized instead of
-raising (confirmed live at the time: `$acme.csvpaths.:name("x")`, a
-FILES-only function, silently did nothing instead of erroring). The fix
-was a declarative `Function3.POSITIONS: dict[datatype, tuple[position,
-...]]` class attribute, checked centrally by one shared `_check_position()`
-call, rolled out incrementally one finder at a time. Whatever `resolve_kind`
-ends up doing should probably follow the same template (a declarative
-class attribute + one shared check) rather than inventing a new pattern.
+## `resolve_kind`'s hardcoded name-tuple dispatch — BUILT 2026-08-28, see `deferred_work_done_list.md`
 
 ## Predicate-argument field accessors (`:on_arrival(:not_none())`) — filter half built for `:idchain()`, generic mechanism still not built
 

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,113 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `resolve_kind`'s hardcoded name-tuple dispatch replaced with `Function3.metadata_kind()` — BUILT 2026-08-28
+
+`Reference3.resolve_kind` used to dispatch `METADATA_FILE`/`METADATA_FIELD`
+classification off two hardcoded name-string tuples,
+`_METADATA_FILE_FUNCTIONS`/`_METADATA_FIELD_FUNCTIONS` (94 names combined) --
+flagged 2026-08-22 as a maintenance cost (every new field accessor needed
+its own name added by hand) with a code comment sitting right above them
+saying "both lists will be replaced by real per-function trait lookups once
+`Function3` exists" -- `Function3` had existed for a while, that refactor
+had just never been done. David: "not yet clear on the meaning/impact of
+this one -- needs a real look... before deciding."
+
+**Investigated before designing anything, not guessed:**
+- `_METADATA_FILE_FUNCTIONS` (10 names) turned out to be **exactly** the
+  set of functions living in `csvpath/references/functions/well_known_files/`
+  -- a perfect 1:1 match, confirmed by listing the directory. But none of
+  them declared anything distinguishing them from an ordinary field
+  accessor (`ROLE = Function3.VALUE`, no `SOURCE`) -- this **is** the
+  "still-unrecognized file/well-known-file accessor category" from the
+  four-function-types discussion David asked whether this connected to --
+  confirmed connected, not speculative.
+- `_METADATA_FIELD_FUNCTIONS` (84 names) turned out to be **exactly**
+  `{every function with SOURCE not in (None, "clock")}` (83 names) **plus
+  one exception, `idchain`** (no `SOURCE` at all, in `functions/filters/`
+  not `functions/fields/`). Confirmed by counting: 83 of 85 files in
+  `fields/` declare `SOURCE`; the one exception (`Home3`) correctly has
+  neither `SOURCE` nor tuple membership -- a real confirming data point.
+  `idchain`'s inclusion is structurally different: it is a nested filter/
+  predicate marker (`:errors(:idchain(...))`) that narrows a whole-
+  resource read into a field-level one, per the already-settled "position
+  decides meaning" rule (2026-08-21) -- not a stored-field read itself.
+- Verified programmatically, not just by counting: iterated all 124
+  functions registered in the factory at the time of the switch, computed
+  each one's classification both the old (tuple-membership) and new
+  (`metadata_kind()`) ways, and confirmed byte-for-byte agreement before
+  removing the tuples -- zero discrepancies in either direction.
+
+**Second goal, stated explicitly by David alongside approving the design**:
+"there are two goals here: 1) make the mechanics work, and 2) make
+functions able to be super-clear in their self-documenting output... it is
+very important that a function can clearly and completely educate a user,
+particularly an AI agent." This shaped the naming and the wiring, not just
+the mechanism:
+
+**Built:**
+
+- **`Function3.RESOLVES_AS: str | None = None`** (new class attribute,
+  `function_3.py`) -- an explicit override, using `Reference3.METADATA_FILE`/
+  `METADATA_FIELD`'s own constants directly rather than a new boolean/enum,
+  specifically so it is self-documenting on sight: reading
+  `Errors3.RESOLVES_AS == Reference3.METADATA_FILE` tells a reader exactly
+  what `resolve_kind` will classify a bare `:errors()` reference as, using
+  the identical vocabulary, not a second name to learn. Needed on only 11
+  classes total: the ten `well_known_files` classes (`Errors3`, `Vars3`,
+  `Meta3`, `Data3`, `Unmatched3`, `Printouts3`, `File3`, `Definition3`,
+  `Manifest3`, `Log3`) get `METADATA_FILE`; `Idchain3` gets `METADATA_FIELD`
+  (with its own docstring explaining why, despite having no `SOURCE`).
+  Every other function needs no override at all -- its own `SOURCE`
+  declaration (already required for its `KEY`-lookup to work) implies
+  `METADATA_FIELD` for free, zero added maintenance for future field
+  accessors.
+- **`Function3.metadata_kind()`** (new classmethod) -- the single shared
+  source of truth: `RESOLVES_AS` if set, else `METADATA_FIELD` when
+  `SOURCE not in (None, "clock")`, else `None`. Both `Reference3.
+  resolve_kind` (chain-walking) and the self-documentation surfaces below
+  read this SAME computation, rather than duplicating the rule in two
+  places that could drift apart.
+- **`Reference3.resolve_kind`** rewritten to walk `terminal_functions` and
+  call `metadata_kind()` via a locally-imported `ReferenceFunctionFactory`
+  (deferred import -- `functions/` already depends on `reference_3.py`,
+  so a module-level import back would be circular; mirrors
+  `InterpolatedString3.check_valid()`'s own already-established deferred-
+  import pattern in this same file). Preserves the exact original
+  precedence: `METADATA_FIELD` checked first and can come from anywhere in
+  a terminal function's own nested-arg chain (mirroring
+  `FunctionCall3.contains_function_named()`'s one-level-of-nesting walk);
+  `METADATA_FILE` only ever checked on the terminal function itself, no
+  nested walk (nothing today nests a whole-resource function as another's
+  argument, so none was needed).
+- **Self-documentation, the second explicit goal**: `Function3.describe()`
+  (the machine-readable dict) now includes `"resolves_as": self.
+  metadata_kind()` -- previously missing `SOURCE`-derived information
+  entirely. `Function3Describer.describe()` (the markdown renderer) gained
+  a new "Resolves as" table row, shown whenever `metadata_kind()` is not
+  `None` -- verified live against `:errors()` (shows `metadata_file`),
+  `:idchain()` (shows `metadata_field` despite having no `Source` row at
+  all -- proving the override, not a `SOURCE` passthrough), `:uuid()`
+  (shows `metadata_field`, derived purely from its own `Source: manifest`
+  row, no override needed), and `:having()` (no `Resolves as` row at all,
+  correctly, same as "having" never appeared in either old tuple).
+
+Tests: new `TestMetadataKind` in `test_function_3.py` (override precedence,
+`SOURCE`-implied default, `clock` exclusion, no-`SOURCE`-no-override case);
+widened `TestResolveKind` in `test_reference_3.py` (an unregistered nested
+function name does not crash); widened `test_function_describer_3.py` (the
+new row across all four cases above); widened `test_describe`'s own
+existing assertion in `test_function_3.py` for the new dict key. The
+existing, already-substantial `TestResolveKind`/`TestTerminalFunctions`
+suites needed no changes at all beyond one stale comment fix (a test
+comment in `test_csvpaths_reference_finder_3.py` referencing the now-
+deleted `_METADATA_FILE_FUNCTIONS` by name) -- they already exercised
+`resolve_kind` through real `Reference3` objects with real function names,
+so they transparently verified the rewrite's correctness as a side effect
+of already existing. Full local-backend suite green (3118/3118, run
+twice); pre-existing SFTP/S3 env-dependent failures unrelated to this
+change.
+
 ## `:regex()` at `root_major` — BUILT 2026-08-27
 
 From the "grammar / argument-type gaps" bucket-list entry: `root_major`

--- a/tests/references/functions/test_function_3.py
+++ b/tests/references/functions/test_function_3.py
@@ -1,7 +1,12 @@
 import pytest
 
 from csvpath.references.functions.function_3 import Function3
-from csvpath.references.reference_3 import FunctionCall3, InterpolatedString3, Variable3
+from csvpath.references.reference_3 import (
+    FunctionCall3,
+    InterpolatedString3,
+    Reference3,
+    Variable3,
+)
 from csvpath.references.reference_exceptions_3 import ReferenceException3
 
 
@@ -132,9 +137,75 @@ class TestProperties:
             "summary": "takes nothing",
             "role": Function3.CONTEXT_SETTER,
             "datatypes": ("files",),
+            "resolves_as": None,
         }
 
     def test_equality(self):
         assert _RequiredIntArgFunction(arg=1) == _RequiredIntArgFunction(arg=1)
         assert _RequiredIntArgFunction(arg=1) != _RequiredIntArgFunction(arg=2)
         assert _RequiredIntArgFunction(arg=1) != _NoArgFunction()
+
+
+class _SourcedFunction(Function3):
+    # mirrors an ordinary field accessor (e.g. Uuid3) -- SOURCE set,
+    # no RESOLVES_AS override needed.
+    NAME = "sourced"
+    SUMMARY = "reads a manifest field"
+    ROLE = Function3.VALUE
+    DATATYPES = ("files",)
+    SOURCE = "manifest"
+    KEY = {"files": "some_key"}
+
+
+class _ClockFunction(Function3):
+    # mirrors a SOURCE == "clock" value function (e.g. Year3) -- must
+    # NOT be treated as METADATA_FIELD despite having a non-None SOURCE.
+    NAME = "clockish"
+    SUMMARY = "a pure computed value"
+    ROLE = Function3.VALUE
+    DATATYPES = ("files",)
+    SOURCE = "clock"
+
+
+class _WholeResourceFunction(Function3):
+    # mirrors a functions/well_known_files/ class (e.g. Errors3) --
+    # explicit RESOLVES_AS override, no SOURCE at all.
+    NAME = "wholeresource"
+    SUMMARY = "reads a whole well-known file"
+    ROLE = Function3.VALUE
+    DATATYPES = ("files",)
+    RESOLVES_AS = Reference3.METADATA_FILE
+
+
+class _NarrowingFunction(Function3):
+    # mirrors Idchain3 -- explicit RESOLVES_AS override to METADATA_FIELD,
+    # despite having no SOURCE either.
+    NAME = "narrows"
+    SUMMARY = "narrows a parent's whole-resource read"
+    ROLE = Function3.VALUE
+    DATATYPES = ("files",)
+    RESOLVES_AS = Reference3.METADATA_FIELD
+
+
+class TestMetadataKind:
+    # added 2026-08-28, replacing Reference3's old hardcoded
+    # _METADATA_FILE_FUNCTIONS/_METADATA_FIELD_FUNCTIONS name tuples --
+    # confirmed by direct inspection (not assumed) that this classmethod
+    # reproduces both tuples' membership exactly, across all 124
+    # functions registered at the time of the switch.
+    def test_plain_function_with_neither_source_nor_override_is_none(self):
+        assert _NoArgFunction.metadata_kind() is None
+
+    def test_source_implies_metadata_field_with_no_override_needed(self):
+        assert _SourcedFunction.metadata_kind() == Reference3.METADATA_FIELD
+
+    def test_clock_source_is_excluded_despite_being_non_none(self):
+        # a bare computed value (e.g. :year()) has no entity/manifest
+        # context at all -- neither METADATA_FILE nor METADATA_FIELD.
+        assert _ClockFunction.metadata_kind() is None
+
+    def test_resolves_as_override_wins_for_whole_resource_functions(self):
+        assert _WholeResourceFunction.metadata_kind() == Reference3.METADATA_FILE
+
+    def test_resolves_as_override_works_with_no_source_at_all(self):
+        assert _NarrowingFunction.metadata_kind() == Reference3.METADATA_FIELD

--- a/tests/references/test_csvpaths_reference_finder_3.py
+++ b/tests/references/test_csvpaths_reference_finder_3.py
@@ -1511,14 +1511,13 @@ class TestScopeLimits:
             finder.query()
 
     def test_metadata_kind_not_yet_supported(self):
-        # :meta() matches resolve_kind's METADATA_FILE placeholder list
-        # (Reference3._METADATA_FILE_FUNCTIONS) even though it is not
-        # an actual registered function -- query() would already reject
-        # this reference for a different reason first (functions on
-        # name_three are rejected outright), so _extract_data() is
-        # called directly to test its own resolve_kind branching in
-        # isolation, ahead of any real metadata-access function
-        # existing for csvpaths.
+        # :meta() is a real registered function (Meta3, RESOLVES_AS ==
+        # Reference3.METADATA_FILE -- see Function3.metadata_kind()),
+        # but query() would already reject this reference for a
+        # different reason first (functions on name_three are rejected
+        # outright for csvpaths), so _extract_data() is called directly
+        # to test its own resolve_kind branching in isolation, ahead of
+        # any real metadata-access function existing for csvpaths.
         finder = _finder("$acme.csvpaths.:first().:meta()")
         with pytest.raises(ReferenceException3):
             finder._extract_data(ReferenceResult3(path="p", uuid="v0-uuid"))

--- a/tests/references/test_function_describer_3.py
+++ b/tests/references/test_function_describer_3.py
@@ -1,9 +1,11 @@
 from csvpath.references.function_describer_3 import Function3Describer
 from csvpath.references.functions.fields.template_3 import Template3
+from csvpath.references.functions.fields.uuid_3 import Uuid3
 from csvpath.references.functions.filters.idchain_3 import Idchain3
 from csvpath.references.functions.reference_function_factory_3 import (
     ReferenceFunctionFactory,
 )
+from csvpath.references.functions.selectors.having_3 import Having3
 from csvpath.references.functions.values.year_3 import Year3
 from csvpath.references.functions.well_known_files.log_3 import Log3
 
@@ -47,6 +49,39 @@ class TestDescribeOneFunction:
     def test_positions_are_rendered_when_declared(self):
         doc = Function3Describer.describe(Template3)
         assert "name_one" in doc
+
+    def test_whole_resource_function_shows_resolves_as_metadata_file(self):
+        # RESOLVES_AS override -- added 2026-08-28, replacing the old
+        # hardcoded _METADATA_FILE_FUNCTIONS tuple.
+        doc = Function3Describer.describe(Log3)
+        assert "Resolves as" in doc
+        assert "metadata_file" in doc
+
+    def test_narrowing_function_with_no_source_still_shows_resolves_as_metadata_field(
+        self,
+    ):
+        # Idchain3 has no SOURCE of its own -- its METADATA_FIELD
+        # classification comes entirely from its own RESOLVES_AS
+        # override, proving the row reflects metadata_kind()'s actual
+        # answer, not just a raw SOURCE passthrough.
+        doc = Function3Describer.describe(Idchain3)
+        assert "Resolves as" in doc
+        assert "metadata_field" in doc
+
+    def test_ordinary_field_accessor_shows_resolves_as_metadata_field_via_source(self):
+        # Uuid3 has no RESOLVES_AS override at all -- metadata_kind()
+        # derives METADATA_FIELD purely from its SOURCE == "manifest".
+        assert Uuid3.RESOLVES_AS is None
+        doc = Function3Describer.describe(Uuid3)
+        assert "Resolves as" in doc
+        assert "metadata_field" in doc
+
+    def test_non_metadata_function_has_no_resolves_as_row(self):
+        # Having3 is a plain CONTEXT_SETTER with no SOURCE and no
+        # RESOLVES_AS -- the row should not appear at all, same as
+        # "having" never appeared in either old hardcoded tuple.
+        doc = Function3Describer.describe(Having3)
+        assert "Resolves as" not in doc
 
 
 class TestDescribeAll:

--- a/tests/references/test_reference_3.py
+++ b/tests/references/test_reference_3.py
@@ -534,6 +534,29 @@ class TestResolveKind:
         )
         assert r.resolve_kind == Reference3.METADATA_FILE
 
+    def test_unregistered_nested_function_name_does_not_crash(self):
+        # added 2026-08-28, alongside the declarative metadata_kind()
+        # rewrite -- an unknown function name anywhere in the chain
+        # (get_registered_class() returns None for it) must be treated
+        # as contributing nothing, same as the old tuple-membership
+        # check already did for free via plain string comparison.
+        r = Reference3(
+            root_major="acme",
+            datatype=Reference3.RESULTS,
+            name_one=self._name_one("a"),
+            name_three=NameThree3(
+                functions=[
+                    FunctionCall3(
+                        name="errors",
+                        arg=FunctionCall3(name="totally_unknown_function"),
+                    )
+                ]
+            ),
+        )
+        # errors() itself is still METADATA_FILE; the unknown nested
+        # name just does not promote it to METADATA_FIELD.
+        assert r.resolve_kind == Reference3.METADATA_FILE
+
     def test_uses_name_one_path_segment_function_when_it_is_the_sole_content(self):
         # a "path-less, function-only" name_one (e.g. ":manifest()" or
         # ":all()" occupying the sole path segment) has its function in


### PR DESCRIPTION
## Summary

Closes a deferred-work bucket-list item: `Reference3.resolve_kind` used to dispatch `METADATA_FILE`/`METADATA_FIELD` classification off two hardcoded name-string tuples (94 names combined), despite a comment sitting right above them since `Function3` was first built saying *"both lists will be replaced by real per-function trait lookups once `Function3` exists"* -- that refactor had just never been done.

**Investigated before designing anything, not guessed:**
- `_METADATA_FILE_FUNCTIONS` (10 names) turned out to be **exactly** the `functions/well_known_files/` directory -- a perfect 1:1 match, confirming this is the "still-unrecognized file/well-known-file accessor category" from an earlier four-function-types discussion.
- `_METADATA_FIELD_FUNCTIONS` (84 names) turned out to be **exactly** every function with `SOURCE not in (None, "clock")`, plus one exception (`idchain` -- a nested filter/predicate marker with no `SOURCE` of its own, structurally different from an ordinary field read).
- Verified programmatically across all 124 registered functions before removing the tuples: zero discrepancies between old and new classification.

**Two explicit goals shaped the design:** make the mechanics work, and make functions clearly self-documenting -- particularly for an AI agent reading the registry.

## What was built

- **`Function3.RESOLVES_AS`** -- a new class attribute using `Reference3`'s own `METADATA_FILE`/`METADATA_FIELD` constants directly (not a new boolean), so it reads as self-evident on sight: `Errors3.RESOLVES_AS == Reference3.METADATA_FILE` tells you exactly what it means, using vocabulary a reader already has. Needed on only 11 classes: the ten `well_known_files` functions, and `Idchain3`. Every other field accessor needs no override at all -- its own `SOURCE` declaration (already required for its `KEY` lookup) implies `METADATA_FIELD` for free.
- **`Function3.metadata_kind()`** -- a shared classmethod combining `RESOLVES_AS` and `SOURCE`, the single source of truth both `resolve_kind` and the self-documentation surfaces read, rather than duplicating the rule.
- **`Reference3.resolve_kind`** rewritten to walk `terminal_functions` and call `metadata_kind()` via a locally-imported `ReferenceFunctionFactory` (deferred import to break the circular dependency -- mirrors this file's own existing `InterpolatedString3.check_valid()` pattern). Preserves the original precedence exactly: `METADATA_FIELD` can come from anywhere in a terminal function's own nested-arg chain; `METADATA_FILE` only from the terminal function itself.
- **Self-documentation**: `Function3.describe()`'s machine dict now includes `resolves_as`; `Function3Describer`'s markdown renderer gained a "Resolves as" row -- verified live to show the right thing whether it comes from an explicit override or is implied by `SOURCE`, and to be absent entirely for functions that are neither.

## Test plan

- [x] New `TestMetadataKind` in `test_function_3.py` (override precedence, `SOURCE`-implied default, `clock` exclusion, no-`SOURCE`-no-override case).
- [x] Widened `test_function_describer_3.py` (the new row across all four cases: explicit override, override-with-no-source, source-implied, absent entirely).
- [x] Widened `TestResolveKind` in `test_reference_3.py` (unregistered nested function name doesn't crash); one stale test comment fixed in `test_csvpaths_reference_finder_3.py`.
- [x] The existing, already-substantial `resolve_kind` test suite needed **no changes** -- it already exercises real function names through real `Reference3` objects, so it transparently verified the rewrite's correctness just by continuing to pass.
- [x] `tests/references/` + `tests/csvpaths/references/`: 1561 passed.
- [x] Full local-backend suite: 3118/3118 passed, run twice for stability. 11 pre-existing SFTP/S3 failures (unset `SFTP_*` env vars, matches issue #216) are unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
