### PR TITLE
Replace bare-fingerprint check with declarative SELECTOR_WHEN_ARGUED

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -247,20 +247,26 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # undefined (only SOURCE == "definition" functions get bare
             # treatment via _bare_definition_field_call).
             candidates = self._candidates_for_name(root_major, [])
-        elif self._is_bare_fingerprint_reference(name_one):
-            # bare ':fingerprint("hash...")' -- added 2026-08-13. Content-
-            # hash identity does not care which file/path slot a version
-            # happens to be registered under (unlike ':name()', which
-            # matches file_home, a path identity, not a content one), so
-            # this searches the WHOLE named-file's manifest directly --
-            # every file_home/path, not just a pattern-matched subset --
-            # for the entry whose own "fingerprint" field matches.
-            # Confirmed against FileRegistrar's real write path: the
-            # version file itself is literally stored/named by its own
-            # fingerprint, so an exact match here is reliable. At most
-            # one match is expected in practice (two DIFFERENT logical
-            # files sharing byte-identical content is the only way to
-            # get more than one) -- not specially guarded against.
+        elif self._is_bare_selector_reference(name_one):
+            # bare ':fingerprint("hash...")' -- added 2026-08-13, the
+            # shape generalized 2026-08-28 (see Function3.
+            # SELECTOR_WHEN_ARGUED/ReferenceFinder3.
+            # _is_bare_selector_reference() -- Fingerprint3 is still the
+            # only function that declares it, so behavior here is
+            # unchanged, just no longer hand-written to the literal name
+            # "fingerprint"). Content-hash identity does not care which
+            # file/path slot a version happens to be registered under
+            # (unlike ':name()', which matches file_home, a path
+            # identity, not a content one), so this searches the WHOLE
+            # named-file's manifest directly -- every file_home/path,
+            # not just a pattern-matched subset -- for the entry whose
+            # own field (this function's own KEY) matches. Confirmed
+            # against FileRegistrar's real write path: the version file
+            # itself is literally stored/named by its own fingerprint,
+            # so an exact match here is reliable. At most one match is
+            # expected in practice (two DIFFERENT logical files sharing
+            # byte-identical content is the only way to get more than
+            # one) -- not specially guarded against.
             #
             # Returns the matched version(s) directly, with their real
             # path/uuid, and does NOT fall through to the shared "no
@@ -270,15 +276,18 @@ class FilesReferenceFinder3(ReferenceFinder3):
             # narrowing step to defer. name_three combined with this
             # shape is not yet supported (redundant by construction --
             # there is nothing left to narrow).
+            call = name_one.path[0]
             if reference.name_three is not None:
                 raise ReferenceException3(
-                    "FilesReferenceFinder3 does not yet support combining "
-                    "a bare ':fingerprint(...)' lookup with name_three -- "
+                    f"FilesReferenceFinder3 does not yet support combining "
+                    f"a bare ':{call.name}(...)' lookup with name_three -- "
                     "it already identifies one specific version on its own."
                 )
+            function_cls = ReferenceFunctionFactory.get_registered_class(call.name)
+            key = function_cls.KEY.get(Reference3.FILES)
             manifest = self.csvpaths.file_manager.get_manifest(root_major)
-            fingerprint = name_one.path[0].arg
-            matched = [e for e in manifest if e.get("fingerprint") == fingerprint]
+            value = call.arg
+            matched = [e for e in manifest if e.get(key) == value]
             return ReferenceResults3(
                 results=[
                     ReferenceResult3(path=e["file"], uuid=e["uuid"]) for e in matched
@@ -958,22 +967,6 @@ class FilesReferenceFinder3(ReferenceFinder3):
         if isinstance(call, FunctionCall3) and call.name == "definition" and call.arg is None:
             return call
         return None
-
-    @staticmethod
-    def _is_bare_fingerprint_reference(name_one) -> bool:
-        """same shape as _is_bare_home_reference, for ':fingerprint(...)'
-        -- settled 2026-08-13, but the OPPOSITE arg requirement: WITH an
-        arg (the hash to search for), not without -- a bare, argument-
-        less ':fingerprint()' has no candidate to read the field off of
-        at this position, so it is deliberately NOT recognized here and
-        falls through to the ordinary "not yet supported" rejection."""
-        return (
-            not name_one.functions
-            and len(name_one.path) == 1
-            and isinstance(name_one.path[0], FunctionCall3)
-            and name_one.path[0].name == "fingerprint"
-            and name_one.path[0].arg is not None
-        )
 
     @staticmethod
     def _is_flatten_prefixed_reference(name_one) -> bool:

--- a/csvpath/references/function_describer_3.py
+++ b/csvpath/references/function_describer_3.py
@@ -71,6 +71,15 @@ class Function3Describer:
         kind = function_cls.metadata_kind()
         if kind:
             rows.append(["Resolves as", kind])
+        if function_cls.SELECTOR_WHEN_ARGUED:
+            rows.append(
+                [
+                    "Selector when argued",
+                    "bare with an argument, selects the entity whose own "
+                    "field matches it, rather than reading a field off an "
+                    "already-selected one",
+                ]
+            )
         lines.append(tabulate(rows, tablefmt="pipe"))
         return "\n".join(lines)
 

--- a/csvpath/references/functions/fields/fingerprint_3.py
+++ b/csvpath/references/functions/fields/fingerprint_3.py
@@ -32,16 +32,19 @@ class Fingerprint3(Function3):
     # search the WHOLE named-file's manifest for the entry whose own
     # fingerprint matches, since content-hash identity does not care
     # which file/path slot a version happens to be registered under
-    # (unlike :name(), which matches file_home, a path identity). See
-    # FilesReferenceFinder3._is_bare_fingerprint_reference/query() for
-    # where this is actually recognized and handled -- this class's own
-    # ROLE stays VALUE (unchanged) specifically so it keeps NOT counting
-    # as a second pointer when it rides alongside a real one in its
-    # ordinary field-accessor position (e.g.
+    # (unlike :name(), which matches file_home, a path identity). This
+    # class's own ROLE stays VALUE (unchanged) specifically so it keeps
+    # NOT counting as a second pointer when it rides alongside a real
+    # one in its ordinary field-accessor position (e.g.
     # ":name('orders.csv').:first():fingerprint()"); the bare-lookup
-    # shape is recognized structurally (bare, sole content of name_one,
-    # WITH an arg), the same way ':all()'/':flatten()'/':groups()'/
-    # ':home()' are already recognized, not via ROLE.
+    # shape is instead recognized declaratively via SELECTOR_WHEN_ARGUED
+    # (added 2026-08-28, replacing the original bespoke, hand-written
+    # FilesReferenceFinder3._is_bare_fingerprint_reference() check -- see
+    # ReferenceFinder3._is_bare_selector_reference() for the shared
+    # mechanism this and any future selector-when-argued function now
+    # go through).
+    #
+    SELECTOR_WHEN_ARGUED = True
     #
     NAME = "fingerprint"
     SUMMARY = (

--- a/csvpath/references/functions/function_3.py
+++ b/csvpath/references/functions/function_3.py
@@ -182,6 +182,29 @@ class Function3:
     KIND: str | None = None
 
     #
+    # true when this function, used BARE (the sole content of name_one,
+    # no chained functions) WITH an argument, selects the entity whose
+    # own field matches that argument, rather than reading a field off
+    # an already-selected entity -- added 2026-08-28, replacing the
+    # bespoke, hand-written FilesReferenceFinder3._is_bare_fingerprint_
+    # reference() (the only place this shape existed before this flag).
+    # Fingerprint3 is the only function that sets this True today
+    # ("$alpha.files.:fingerprint('hash...')" searches the whole named-
+    # file's manifest for the entry whose own "fingerprint" field
+    # matches -- see its own docstring). ROLE stays declared VALUE
+    # either way, so this never wrongly counts as a second pointer
+    # riding beside a real one in this function's ordinary field-
+    # accessor position. See ReferenceFinder3._is_bare_selector_
+    # reference() for the shared, generic recognition this replaces the
+    # hand-written check with. Cross-datatype "select by known uuid"/
+    # set-operations (the bigger ask this flag was extracted from) is
+    # deliberately NOT part of this -- see the deferred-work bucket
+    # list's "Function self-documentation" entry for that larger,
+    # still-undesigned piece.
+    #
+    SELECTOR_WHEN_ARGUED: bool = False
+
+    #
     # SOURCE == "clock" (added 2026-08-26): a fourth SOURCE value for
     # the compendium's own "dumb value-producing functions" (5.29 --
     # :year()/:month()/:day()/:hour()/etc.) -- these are never stored
@@ -314,13 +337,17 @@ class Function3:
         see exactly what it contributes to a reference's own
         Reference3.resolve_kind() classification, without needing to
         already understand the RESOLVES_AS/SOURCE mechanics behind
-        metadata_kind() itself."""
+        metadata_kind() itself. "selector_when_argued" (added 2026-08-28)
+        surfaces SELECTOR_WHEN_ARGUED the same way -- always present,
+        so a reader can tell "not a selector" (False) apart from
+        "wasn't asked" (missing key)."""
         return {
             "name": self.NAME,
             "summary": self.SUMMARY,
             "role": self.ROLE,
             "datatypes": self.DATATYPES,
             "resolves_as": self.metadata_kind(),
+            "selector_when_argued": self.SELECTOR_WHEN_ARGUED,
         }
 
     def __eq__(self, other) -> bool:

--- a/csvpath/references/reference_finder_3.py
+++ b/csvpath/references/reference_finder_3.py
@@ -593,6 +593,39 @@ class ReferenceFinder3(ABC):
             return names
         return [n for n in names if re.search(name_filter, n)]
 
+    @staticmethod
+    def _is_bare_selector_reference(name_one) -> bool:
+        """true when name_one's entire content is a single, argued
+        FunctionCall3 whose registered Function3 class declares
+        SELECTOR_WHEN_ARGUED -- e.g. ':fingerprint("hash...")' as
+        name_one's sole content, selecting the entity whose own
+        fingerprint field matches, rather than reading a field off an
+        already-selected one. Added 2026-08-28 as the generic,
+        declarative replacement for FilesReferenceFinder3's own
+        original bespoke, hand-written _is_bare_fingerprint_reference()
+        -- same structural shape every _is_bare_X_reference sibling
+        there already uses (no chained functions, exactly one path
+        segment, that segment a FunctionCall3), just with the function-
+        name check replaced by a registry lookup so any future
+        SELECTOR_WHEN_ARGUED function is recognized here for free,
+        without a new hand-written check per function. The OPPOSITE arg
+        requirement from ':all()'/':flatten()'/':groups()'/':home()'
+        (WITH an argument, not without) mirrors
+        _is_bare_fingerprint_reference()'s own original reasoning: a
+        bare, argument-less call has no value to search a manifest
+        for, so it is deliberately not recognized here."""
+        if name_one.functions:
+            return False
+        if len(name_one.path) != 1 or not isinstance(
+            name_one.path[0], FunctionCall3
+        ):
+            return False
+        call = name_one.path[0]
+        if call.arg is None:
+            return False
+        function_cls = ReferenceFunctionFactory.get_registered_class(call.name)
+        return function_cls is not None and function_cls.SELECTOR_WHEN_ARGUED
+
     def _resolve_value(self, value):
         """returns `value` unchanged if it is a plain literal (str, int,
         etc.); resolves it if it is a bare Variable3 (added 2026-08-27,

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -48,8 +48,6 @@ candidates for that re-audit, all still unconditional/immediate raises in
   same "was a pointer actually applied within each partition" reasoning
   the literal-root fix used, not a blind port.
 
-## `resolve_kind`'s hardcoded name-tuple dispatch — BUILT 2026-08-28, see `deferred_work_done_list.md`
-
 ## Predicate-argument field accessors (`:on_arrival(:not_none())`) — filter half built for `:idchain()`, generic mechanism still not built
 
 David, 2026-08-21, drafting the compendium's replacement `:manifest()`/
@@ -203,41 +201,39 @@ a named worksheet across every named-file matched by `'*'`.
 
 ## Function self-documentation — dual selector/value-accessor behavior
 
-- **`:uuid(known_uuid)` should select the entity whose uuid *is* that value**
-  (probably via `@variable`), not just read the uuid off an already-selected
-  one. Currently `Uuid3.ARG_TYPES = ()` — any argument at all is rejected
-  outright.
-- **`:fingerprint(...)` already does exactly this, but only for FILES, and
-  only as a one-off special case** — `$alpha.files.:fingerprint('hash...')`
-  (bare, sole content of name_one, with an arg) searches the whole named-
-  file's manifest for the entry whose own fingerprint matches
-  (`fingerprint_3.py:15-30`). `ROLE` stays `VALUE` (so it never wrongly
-  counts as a second pointer riding beside a real one); the selector
-  behavior is recognized structurally by a bespoke, hand-written
-  `FilesReferenceFinder3._is_bare_fingerprint_reference()` check — the only
-  place this pattern exists today. Not generalized to CSVPATHS/RESULTS, and
-  not built for any other field accessor.
-- **`:idchain("add[0]")` already does the same underlying thing, one level
-  down** — it doesn't just extract a value, it filters `errors.json`'s
-  array to entries whose own `"source"` field matches the given chain
-  string. Same "match against your own key/field, not just read it" idea,
-  applied to array elements instead of whole entities. (`ARG_REQUIRED =
-  True` today — no bare, unargued form exists or is implied to mean
-  anything yet.)
-- **The general capability doesn't exist as a declarative mechanism** —
-  each instance so far is its own hand-built, per-function, per-finder
-  special case (`_is_bare_fingerprint_reference`, the pointer-adjacent
-  `:home()`/`:all()`/`:flatten()`/`:groups()` structural checks). Proposed
-  direction, discussed 2026-08-21 (David: "we don't need to subclass, but
-  we do need to be able to indicate that certain functions may select
-  files or retrieve values, depending on how they are used" — mirroring
-  match functions' own `ValueProducer`/`MatchDecider` idea, but declaratively
-  rather than via subclassing): a new `Function3` class attribute (e.g.
-  `SELECTOR_WHEN_ARGUED`), defaulting `False`, that a single shared helper
-  checks the same way `_is_bare_pointer_reference`/
-  `_is_bare_fingerprint_reference` already do today, generically instead of
-  one hand-written check per function. `ROLE` stays declared `VALUE`
-  either way, for the same reason `Fingerprint3` already needs it to.
+The declarative `SELECTOR_WHEN_ARGUED` mechanism itself is **BUILT
+2026-08-28** — see `deferred_work_done_list.md`. Still open, deliberately
+NOT part of that build:
+
+- **`:idchain("add[0]")` already does a related thing, one level down** —
+  it doesn't just extract a value, it filters `errors.json`'s array to
+  entries whose own `"source"` field matches the given chain string. Same
+  "match against your own key/field, not just read it" idea as
+  `SELECTOR_WHEN_ARGUED`, but applied to array elements inside an already-
+  selected entity, not to selecting the entity itself — a different shape,
+  not migrated onto the new flag. (`ARG_REQUIRED = True` today — no bare,
+  unargued form exists or is implied to mean anything yet.)
+
+- **Cross-datatype "select by known uuid" + set operations — reframed
+  2026-08-28 (David), still fully open.** UUID is the connective tissue
+  between *every* datatype: every place the system registers/loads
+  something (a named-file version, a named-paths group version) or
+  generates something (a run, a run's per-file instance) attaches a uuid
+  that links it to the other datatypes. So "select an entity by a known
+  uuid, and do set operations (union/intersect/exclude) across uuid-linked
+  entities across datatypes" is a wide, foundational capability, not a
+  one-function special case — closer in size to the predicate-argument
+  mechanism above than to a single-function fix. Two separate pieces, both
+  undesigned:
+  1. **What "select by uuid" means per datatype** — a different lookup
+     shape for a named-file entry vs. a named-paths group vs. a run vs. a
+     run's file vs. a result.
+  2. **What "set operations" over uuid-linked entities means** — e.g. "the
+     files that fed this run," "the runs that consumed this file"; a
+     genuinely new query capability, not just a selector.
+  Needs worked examples per datatype before anything is buildable —
+  currently `Uuid3.ARG_TYPES = ()`, any argument at all is rejected
+  outright, so nothing here parses yet.
 
 ## Grammar / argument-type gaps (spec says it should work, code doesn't yet)
 

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,84 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `SELECTOR_WHEN_ARGUED` — declarative dual selector/value-accessor mechanism — BUILT 2026-08-28
+
+Replaces `FilesReferenceFinder3`'s original bespoke, hand-written
+`_is_bare_fingerprint_reference()` check with a generic, declarative
+`Function3` class attribute plus one shared recognition helper — the same
+declarative-over-hardcoded-check pattern just proven out for `resolve_kind`
+(see the entry below), applied here to a different gap. Proposed direction
+originally discussed 2026-08-21 (David: "we don't need to subclass, but we
+do need to be able to indicate that certain functions may select files or
+retrieve values, depending on how they are used").
+
+**Scoping decision, 2026-08-28**: the bucket-list entry this came from
+originally bundled two different-sized things — the declarative-refactor
+mechanism itself, and the much bigger, cross-datatype "select an entity by a
+known uuid, plus set operations across uuid-linked entities" capability
+David reframed the same day (see the bucket list's own updated "Function
+self-documentation" entry). Explicitly split: only the small, safe,
+behavior-preserving refactor is built here. The bigger uuid-selection/set-
+operations capability is deferred as its own design thread, needing worked
+examples per datatype first.
+
+**What was built:**
+- `Function3.SELECTOR_WHEN_ARGUED: bool = False` — a new declarative class
+  attribute (`function_3.py`). `True` when a function, used BARE (the sole
+  content of `name_one`, no chained functions) WITH an argument, selects
+  the entity whose own field matches that argument, rather than reading a
+  field off an already-selected entity. `ROLE` stays declared `VALUE`
+  either way, unchanged from before — this flag governs a structural
+  recognition, not the function's own role.
+- `ReferenceFinder3._is_bare_selector_reference(name_one)` — new shared
+  `@staticmethod` on the ABC (`reference_finder_3.py`), mirroring
+  `_is_traversal_root`/`_matching_names`'s own recent placement there. Same
+  structural shape every `_is_bare_X_reference` sibling in
+  `FilesReferenceFinder3` already uses (no chained functions, exactly one
+  path segment, that segment a `FunctionCall3`, WITH an arg present) — only
+  the function-name check is replaced with a `ReferenceFunctionFactory`
+  registry lookup of `SELECTOR_WHEN_ARGUED`, so any future function that
+  declares the flag is recognized here for free, with zero finder-side
+  changes needed.
+- `Fingerprint3.SELECTOR_WHEN_ARGUED = True` — the only function that
+  declares it today. Its own docstring updated to point at the new shared
+  mechanism instead of the old bespoke check.
+- `FilesReferenceFinder3.query()`'s bare-fingerprint branch: condition
+  swapped from `_is_bare_fingerprint_reference(name_one)` to
+  `_is_bare_selector_reference(name_one)`; the manifest-field lookup itself
+  generalized too (was hardcoded to the literal string `"fingerprint"`, now
+  reads the matched function's own `KEY[Reference3.FILES]`), and the
+  name_three-rejection error message generalized to name the actual
+  function (`call.name`) rather than hardcoding `"fingerprint"` in the
+  message text. `Fingerprint3.KEY[Reference3.FILES] == "fingerprint"`, so
+  behavior is byte-for-byte unchanged — confirmed via the full existing
+  `test_files_reference_finder_3.py` bare-fingerprint test coverage
+  (`test_two_different_logical_files_sharing_one_fingerprint_both_come_back`
+  and siblings), none of which needed changing.
+- `FilesReferenceFinder3._is_bare_fingerprint_reference()` removed entirely
+  — confirmed via grep no other call site referenced it before deleting.
+- `Function3.describe()` widened with a `"selector_when_argued"` key
+  (always present, mirroring `"resolves_as"`'s own always-present
+  convention) and `Function3Describer.describe()` widened with a "Selector
+  when argued" markdown row (only rendered when `True`, same convention as
+  the "Resolves as" row) — both goals from the `resolve_kind` PR restated
+  by David apply here too: mechanics AND self-documentation, so an AI agent
+  reading a function's own description can see this trait without already
+  knowing the mechanism exists.
+
+**Tests added**: `TestIsBareSelectorReference` (7 cases, mirroring
+`TestIsBarePointerReference`'s own shape) in `test_reference_finder_3.py`;
+`TestSelectorWhenArgued` (default-False, can-be-declared-True, surfaces-in-
+describe) in `test_function_3.py`; two new describer-row tests in
+`test_function_describer_3.py`; `test_fingerprint_3.py`'s `test_metadata`
+widened with a `SELECTOR_WHEN_ARGUED is True` assertion, and its stale
+comment referencing the removed `_is_bare_fingerprint_reference` by name
+corrected. Full suite run twice, stable both times: 3136 passed, 11 failed
+(the known, unrelated SFTP/S3 failures requiring unset env vars — issue
+#216), identical both runs.
+
+---
+
 ## `resolve_kind`'s hardcoded name-tuple dispatch replaced with `Function3.metadata_kind()` — BUILT 2026-08-28
 
 `Reference3.resolve_kind` used to dispatch `METADATA_FILE`/`METADATA_FIELD`

--- a/tests/references/functions/fields/test_fingerprint_3.py
+++ b/tests/references/functions/fields/test_fingerprint_3.py
@@ -16,6 +16,7 @@ def test_metadata():
         Reference3.FILES: "fingerprint",
         Reference3.CSVPATHS: "fingerprint",
     }
+    assert f.SELECTOR_WHEN_ARGUED is True
 
 
 def test_no_arg_is_valid():
@@ -25,7 +26,9 @@ def test_no_arg_is_valid():
 def test_str_arg_is_valid():
     # settled 2026-08-13: an optional str arg supports the bare-lookup
     # shape for FILES ("$alpha.files.:fingerprint('hash...')") -- see
-    # FilesReferenceFinder3._is_bare_fingerprint_reference/query().
+    # ReferenceFinder3._is_bare_selector_reference()/
+    # FilesReferenceFinder3.query() (generalized 2026-08-28 via
+    # SELECTOR_WHEN_ARGUED).
     Fingerprint3(arg="x").check_valid()  # should not raise
 
 

--- a/tests/references/functions/test_function_3.py
+++ b/tests/references/functions/test_function_3.py
@@ -138,6 +138,7 @@ class TestProperties:
             "role": Function3.CONTEXT_SETTER,
             "datatypes": ("files",),
             "resolves_as": None,
+            "selector_when_argued": False,
         }
 
     def test_equality(self):
@@ -209,3 +210,29 @@ class TestMetadataKind:
 
     def test_resolves_as_override_works_with_no_source_at_all(self):
         assert _NarrowingFunction.metadata_kind() == Reference3.METADATA_FIELD
+
+
+class TestSelectorWhenArgued:
+    # added 2026-08-28 -- declarative replacement for
+    # FilesReferenceFinder3's original bespoke
+    # _is_bare_fingerprint_reference(). See ReferenceFinder3.
+    # _is_bare_selector_reference() for the shared recognition helper
+    # that reads this flag.
+    def test_defaults_to_false(self):
+        assert _NoArgFunction.SELECTOR_WHEN_ARGUED is False
+
+    def test_can_be_declared_true(self):
+        class _SelectorFunction(Function3):
+            NAME = "selectorish"
+            SUMMARY = "selects by a known field value when argued"
+            ROLE = Function3.VALUE
+            DATATYPES = ("files",)
+            ARG_TYPES = (str,)
+            ARG_REQUIRED = False
+            SELECTOR_WHEN_ARGUED = True
+
+        assert _SelectorFunction.SELECTOR_WHEN_ARGUED is True
+
+    def test_surfaces_in_describe(self):
+        f = _NoArgFunction()
+        assert f.describe()["selector_when_argued"] is False

--- a/tests/references/test_function_describer_3.py
+++ b/tests/references/test_function_describer_3.py
@@ -1,4 +1,5 @@
 from csvpath.references.function_describer_3 import Function3Describer
+from csvpath.references.functions.fields.fingerprint_3 import Fingerprint3
 from csvpath.references.functions.fields.template_3 import Template3
 from csvpath.references.functions.fields.uuid_3 import Uuid3
 from csvpath.references.functions.filters.idchain_3 import Idchain3
@@ -75,6 +76,16 @@ class TestDescribeOneFunction:
         doc = Function3Describer.describe(Uuid3)
         assert "Resolves as" in doc
         assert "metadata_field" in doc
+
+    def test_selector_when_argued_function_shows_its_own_row(self):
+        # added 2026-08-28 -- Fingerprint3 is the only function that
+        # declares SELECTOR_WHEN_ARGUED today.
+        doc = Function3Describer.describe(Fingerprint3)
+        assert "Selector when argued" in doc
+
+    def test_non_selector_function_has_no_selector_when_argued_row(self):
+        doc = Function3Describer.describe(Uuid3)
+        assert "Selector when argued" not in doc
 
     def test_non_metadata_function_has_no_resolves_as_row(self):
         # Having3 is a plain CONTEXT_SETTER with no SOURCE and no

--- a/tests/references/test_reference_finder_3.py
+++ b/tests/references/test_reference_finder_3.py
@@ -153,6 +153,50 @@ class TestIsBarePointerReference:
         assert not ReferenceFinder3._is_bare_pointer_reference(r, "manifest")
 
 
+class TestIsBareSelectorReference:
+    # added 2026-08-28 alongside Function3.SELECTOR_WHEN_ARGUED -- the
+    # generic replacement for FilesReferenceFinder3's original bespoke
+    # _is_bare_fingerprint_reference(). "fingerprint" is a real
+    # registered function that declares SELECTOR_WHEN_ARGUED = True;
+    # "all" is a real registered function that does not, used as the
+    # negative control.
+    def test_true_for_bare_argued_selector_function(self):
+        name_one = NameOne3(path=[FunctionCall3(name="fingerprint", arg="x")])
+        assert ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_when_no_arg(self):
+        # mirrors _is_bare_fingerprint_reference's own original
+        # reasoning -- a bare, argument-less call has nothing to search
+        # a manifest for, so it is deliberately not recognized here.
+        name_one = NameOne3(path=[FunctionCall3(name="fingerprint")])
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_for_function_that_does_not_declare_the_flag(self):
+        name_one = NameOne3(path=[FunctionCall3(name="all", arg="x")])
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_for_unregistered_function_name(self):
+        name_one = NameOne3(path=[FunctionCall3(name="bogus", arg="x")])
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_with_extra_path_segment(self):
+        name_one = NameOne3(
+            path=["a", FunctionCall3(name="fingerprint", arg="x")]
+        )
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_with_trailing_functions(self):
+        name_one = NameOne3(
+            path=[FunctionCall3(name="fingerprint", arg="x")],
+            functions=[FunctionCall3(name="first")],
+        )
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+    def test_false_for_literal_path_segment(self):
+        name_one = NameOne3(path=["fingerprint"])
+        assert not ReferenceFinder3._is_bare_selector_reference(name_one)
+
+
 class TestPointerBeforeManifest:
     # shared by every finder that supports ordinal indexing into a
     # global ledger (Rule 1b) -- files/csvpaths/results all read a flat


### PR DESCRIPTION
## Summary

Replaces `FilesReferenceFinder3`'s original bespoke, hand-written
`_is_bare_fingerprint_reference()` check with a generic, declarative
mechanism, following the same pattern the just-merged `resolve_kind`
PR (#270) used for a different gap.

- `Function3.SELECTOR_WHEN_ARGUED: bool = False` (new class attribute,
  `function_3.py`) — `True` when a function, used BARE (the sole
  content of `name_one`, no chained functions) WITH an argument,
  selects the entity whose own field matches that argument, rather
  than reading a field off an already-selected entity. `ROLE` stays
  declared `VALUE` either way, unchanged from before.
- `ReferenceFinder3._is_bare_selector_reference(name_one)` — new
  shared `@staticmethod` on the ABC, mirroring the recent
  `_is_traversal_root`/`_matching_names` placement there. Same
  structural shape every `_is_bare_X_reference` sibling in
  `FilesReferenceFinder3` already uses; only the function-name check
  is replaced with a `ReferenceFunctionFactory` registry lookup, so
  any future `SELECTOR_WHEN_ARGUED` function is recognized for free,
  with zero finder-side changes needed.
- `Fingerprint3.SELECTOR_WHEN_ARGUED = True` — the only function that
  declares it today.
- `FilesReferenceFinder3.query()`'s bare-fingerprint branch:
  generalized to the new flag/helper, and the manifest-field lookup
  itself generalized too (was hardcoded to the literal string
  `"fingerprint"`, now reads the matched function's own
  `KEY[Reference3.FILES]`). `Fingerprint3.KEY[Reference3.FILES] ==
  "fingerprint"`, so behavior is byte-for-byte unchanged.
- `_is_bare_fingerprint_reference()` removed entirely (confirmed via
  grep no other call site referenced it).
- `Function3.describe()`/`Function3Describer.describe()` widened with
  a `selector_when_argued` key/row, so a function's own
  self-description surfaces this trait directly — same
  mechanics-plus-self-documentation goal David restated for the
  `resolve_kind` PR.

## Scoping note

The bucket-list entry this came from originally bundled two
different-sized things: this small, declarative-refactor mechanism,
and a much bigger "select an entity by a known uuid, plus set
operations across uuid-linked entities" capability. David reframed
that second piece during this PR's planning: UUID is the connective
tissue between every datatype (every registration/load and every
run/run-instance generation attaches a uuid linking it to other
datatypes), so uuid-based selection and set operations need to work
broadly across FILES/CSVPATHS/RESULTS, not as a one-function special
case like `:fingerprint()`. That's explicitly deferred as its own
design thread (needs worked examples per datatype before anything is
buildable) — this PR is only the small, safe, behavior-preserving
refactor. See the updated "Function self-documentation" entry in
`deferred_work_bucket_list.md` and the new writeup in
`deferred_work_done_list.md` for the full reasoning trail.

## Test plan

- [x] New `TestIsBareSelectorReference` (7 cases) in
      `test_reference_finder_3.py`, mirroring
      `TestIsBarePointerReference`'s own shape.
- [x] New `TestSelectorWhenArgued` in `test_function_3.py`
      (default-False, can-be-declared-True, surfaces-in-describe).
- [x] Two new describer-row tests in `test_function_describer_3.py`.
- [x] `test_fingerprint_3.py`'s `test_metadata` widened with a
      `SELECTOR_WHEN_ARGUED is True` assertion; stale comment
      referencing the removed method by name corrected.
- [x] `tests/references/` full tree: 1543 passed.
- [x] Full suite run twice for stability: 3136 passed, 11 failed both
      times (identical) — the known, unrelated SFTP/S3 failures
      requiring unset env vars (issue #216).

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
