### PR TITLE
Support bare :manifest() + chained field accessor for FILES

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -1,3 +1,5 @@
+import re
+
 from csvpath.util.file_readers import DataFileReader
 from csvpath.util.nos import Nos
 from csvpath.util.xlsx.xlsx_reader_helper import XlsxReaderHelper
@@ -201,6 +203,34 @@ class FilesReferenceFinder3(ReferenceFinder3):
             home = self.csvpaths.file_manager.named_file_home(root_major)
             path = Nos(home).join("definition.json")
             return ReferenceResults3(results=[ReferenceResult3(path=path, uuid=None)])
+
+        manifest_field_call = self._bare_manifest_field_call(name_one)
+        if manifest_field_call is not None:
+            # ':manifest():uuid()'/':manifest():time()' -- added
+            # 2026-08-28, David's own worked example ("get all acme
+            # registration uuids"). Maps the chained field over EVERY
+            # entry in this named-file's own manifest.json, one
+            # ReferenceResult3 per entry -- resolve()'s existing
+            # per-result "for result in results.results: result.data =
+            # self._extract_data(result)" loop already turns N results
+            # into N resolved values for free (confirmed by reading it
+            # before building this, see reference_finder_3.py's own
+            # resolve_from()), so no new resolution machinery is needed
+            # at that layer, only here (producing N real results) and
+            # in _extract_data() (reading the field per result).
+            if reference.name_three is not None:
+                raise ReferenceException3(
+                    f"FilesReferenceFinder3 does not yet support combining a "
+                    f"bare ':manifest():{manifest_field_call.name}()' lookup "
+                    "with name_three -- it already reads a field from every "
+                    "matched entry on its own."
+                )
+            manifest = self.csvpaths.file_manager.get_manifest(root_major)
+            return ReferenceResults3(
+                results=[
+                    ReferenceResult3(path=e["file"], uuid=e["uuid"]) for e in manifest
+                ]
+            )
 
         if name_one.functions:
             raise ReferenceException3(
@@ -719,6 +749,37 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 self.csvpaths.file_manager.named_file_names, name_filter
             ):
                 candidates.extend(self._candidates_for_name(name, []))
+        elif self._bare_manifest_field_call(name_one) is not None:
+            # ':manifest():uuid()' during '*' traversal -- added
+            # 2026-08-28, David's own worked example ("get uuids from
+            # all registrations"). Reads the global arrivals ledger
+            # (Rule 1a's own resource for bare ':manifest()' at '*'
+            # root), not each named-file's own manifest -- "every
+            # registration across every named-file" is literally what
+            # that ledger already tracks, so this stays consistent with
+            # Rule 1a rather than reassembling the same set by iterating
+            # every name's own manifest. `name_filter` (:regex() at
+            # root_major) is applied against each entry's own
+            # "named_file_name" field, since the ledger is a flat list,
+            # not organized by name the way per-name enumeration is
+            # elsewhere in this method.
+            manifest_field_call = self._bare_manifest_field_call(name_one)
+            if reference.name_three is not None:
+                raise ReferenceException3(
+                    f"FilesReferenceFinder3 does not yet support combining a "
+                    f"bare ':manifest():{manifest_field_call.name}()' lookup "
+                    "with name_three during '*' traversal -- it already "
+                    "reads a field from every matched entry on its own."
+                )
+            ledger = self.csvpaths.file_manager.files_root_manifest
+            return ReferenceResults3(
+                results=[
+                    ReferenceResult3(path=e["file_path"], uuid=e["uuid"])
+                    for e in ledger
+                    if name_filter is None
+                    or re.search(name_filter, e["named_file_name"])
+                ]
+            )
         else:
             if name_one.functions:
                 raise ReferenceException3(
@@ -1008,6 +1069,45 @@ class FilesReferenceFinder3(ReferenceFinder3):
         return len(flatten_indices) == 1 and flatten_indices[0] > 0
 
     @staticmethod
+    def _bare_manifest_field_call(name_one) -> "FunctionCall3 | None":
+        """returns the field-accessor FunctionCall3 chained onto a bare,
+        argument-less ':manifest()' occupying name_one's own path (e.g.
+        ':manifest():uuid()', ':manifest():time()'), or None if this
+        shape does not apply. Added 2026-08-28, David's own worked
+        examples ("get uuids from all registrations," "get all acme
+        registration uuids") -- maps the given field over EVERY entry in
+        the matched manifest (the named-file's own, for a literal root;
+        the global arrivals ledger, for '*'), unlike the ordinary field-
+        accessor position (riding beside a real pointer in name_three),
+        which reads the field off exactly the one entity a pointer
+        already picked. David confirmed both remain valid, distinct
+        ways to reach the same kind of value (narrow to one version via
+        :name(...)+pointer, THEN :uuid() in name_three; or map :uuid()
+        over every version at once via this shape) -- this does not
+        touch or replace the name_three path at all.
+
+        Requires exactly one chained function -- picking one field per
+        entry from more than one chained accessor at once is not a
+        shape any worked example has asked for yet, so left unbuilt
+        rather than guessed at."""
+        if (
+            len(name_one.path) != 1
+            or not isinstance(name_one.path[0], FunctionCall3)
+            or name_one.path[0].name != "manifest"
+            or name_one.path[0].arg is not None
+        ):
+            return None
+        if len(name_one.functions) != 1:
+            return None
+        call = name_one.functions[0]
+        if not isinstance(call, FunctionCall3):
+            return None
+        function_cls = ReferenceFunctionFactory.get_registered_class(call.name)
+        if function_cls is None or function_cls.SOURCE is None:
+            return None
+        return call
+
+    @staticmethod
     def _bare_definition_field_call(name_one) -> "FunctionCall3 | None":
         """returns the field-accessor FunctionCall3 when name_one's
         entire content is a single function whose registered class is
@@ -1138,6 +1238,19 @@ class FilesReferenceFinder3(ReferenceFinder3):
                 # function reached here specifically because NO version
                 # was selected at all, same reasoning.
                 field_call = self._bare_definition_field_call(reference.name_one)
+                if field_call is None:
+                    # ':manifest():uuid()'-style, chained onto a bare
+                    # ':manifest()' in name_one rather than definition-
+                    # sourced -- added 2026-08-28, see query()'s/
+                    # _query_star_traversal()'s own comment on this
+                    # shape. result.uuid is real here (query() built it
+                    # from the actual matched manifest entry), so the
+                    # ordinary manifest-entry-by-uuid read below applies
+                    # unchanged -- only the "which manifest to search"
+                    # step (just below) needs to know about '*' root.
+                    field_call = self._bare_manifest_field_call(
+                        reference.name_one
+                    )
             if field_call is not None:
                 function_cls = ReferenceFunctionFactory.get_registered_class(
                     field_call.name
@@ -1165,9 +1278,24 @@ class FilesReferenceFinder3(ReferenceFinder3):
                     )
                     entry = config.model_dump(exclude_none=True)
                     return self._extract_field_value(entry, key_path)
-                manifest = self.csvpaths.file_manager.get_manifest(
-                    reference.root_major
-                )
+                if isinstance(reference.root_major, Star3):
+                    # ':manifest():uuid()' during '*' traversal -- added
+                    # 2026-08-28. root_major is the '*' token itself
+                    # here, not a real name, so get_manifest() cannot be
+                    # called with it -- read the same global arrivals
+                    # ledger query()'s own '*'-traversal branch built
+                    # these results from instead (this shape is the
+                    # only way a name_three-less, root_major-is-Star3
+                    # METADATA_FIELD read reaches this far -- the
+                    # ordinary name_three field-accessor position still
+                    # unconditionally rejects '*' traversal in
+                    # _query_star_traversal(), so this branch is never
+                    # reached for that shape).
+                    manifest = self.csvpaths.file_manager.files_root_manifest
+                else:
+                    manifest = self.csvpaths.file_manager.get_manifest(
+                        reference.root_major
+                    )
                 entry = self._find_manifest_entry_by_uuid(manifest, result.uuid)
                 return self._extract_field_value_with_ledger_fallback(
                     entry=entry,

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -256,6 +256,32 @@ and a stale-entry correction, are both done — see
   case.
 - `:having()` for RESULTS — **BUILT 2026-08-27**, see
   `deferred_work_done_list.md`.
+- **Found 2026-08-28, while checking David's own uuid-set-operation worked
+  examples (see the `SELECTOR_WHEN_ARGUED` entry above) — a silent-drop
+  risk, not just a missing feature.** `$*.results.:flatten():manifest()
+  :named_file_uuid()` (a content-accessor chain riding directly on
+  `:flatten()` in `name_one.functions`, no separating `.` before
+  `:manifest()`) does NOT raise. `_star_run_selector_chain()` recognizes
+  and exempts `:manifest()`/a field-accessor call from its own "unsupported
+  function" rejection — but its caller
+  (`_query_star_traversal`'s `_is_bare_function_only` branch) only ever
+  unpacks `(pointer, all_call, flatten_call, having_call)` from it, never
+  the recognized `manifest_call`/`field_call`. The `accessor` that
+  actually gets applied comes from a separate call,
+  `_name_three_selector(reference.name_three)`, which is `None` here since
+  nothing follows a `.` after `:flatten()`. Net effect: the query silently
+  returns the flattened, unreduced run list — NOT `named_file_uuid`
+  values — with no error telling the caller their accessor was ignored.
+  The shape that IS wired up correctly needs an explicit `.` before the
+  accessor chain (`$*.results.:flatten().:manifest():named_file_uuid()`,
+  routing it into `name_three`) — confirmed via live parse this puts the
+  calls in the right place, though the field itself
+  (`NamedFileUuid3`, `POSITIONS = {RESULTS: (NAME_ONE,)}`) has not been
+  end-to-end tested via this exact dotted path. Needs a decision: either
+  make the undotted shape actually apply the accessor it already
+  recognizes (matching what a user would naturally write), or make it
+  raise instead of silently dropping — silently ignoring recognized syntax
+  is worse than either.
 
 ## `'*'` traversal — FILES, essentially untouched by the recent RESULTS/CSVPATHS work
 
@@ -287,6 +313,14 @@ and a stale-entry correction, are both done — see
      (`$*.files.:home():definition(:on_arrival(:not_none()))`) still
      cannot parse until this lands — #1/#2/#3 were tested with the
      predicate dropped, per the done-list entry's own worked examples.
+- **Bare `:manifest()` combined with one chained field accessor (e.g.
+  `:manifest():uuid()`, `:manifest():time()`), literal-root and `'*'`
+  alike — BUILT 2026-08-28**, see `deferred_work_done_list.md`. Driven by
+  David's own worked examples ("get uuids from all registrations," "get
+  all acme registration uuids"). `:all()`/`:flatten()`/`:groups()`
+  combined with a chained field accessor is a related but distinct
+  question (partitioning semantics differ per marker), still open, just
+  below.
 - FILES' `:all()`/`:groups()` (GROUP modes) combined with `:manifest()`/
   a field-accessor — same single-entity-vs-grouping restriction RESULTS'
   `name_three` content accessor now has, not yet built for FILES.

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,109 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## Bare `:manifest()` combined with a chained field accessor (FILES) — BUILT 2026-08-28
+
+`$acme.files.:manifest():uuid()`/`$*.files.:manifest():uuid()` now work,
+literal-root and `'*'` alike. Driven directly by David's own worked
+examples (2026-08-28), written while scoping cross-datatype uuid selection/
+set-operations (see the `SELECTOR_WHEN_ARGUED` entry below): "get uuids
+from all registrations," "get all acme registration uuids," each meant to
+combine with `SUBTRACT`/`INTERSECT` against another reference expression.
+
+**Investigated before designing anything, not guessed.** David's first
+framing of the gap was "does this need a `.` before the field accessor" —
+traced live (parsing both forms) and by code-reading before answering:
+that framing turned out to be a red herring. `:first():fingerprint()`
+(pointer + field accessor, no dot, order-independent) already works today
+— but only because it reads a field off exactly ONE already-selected
+entity. `:manifest()` bare does not select one entity, it means "every
+entry in the manifest" (Rule 1a/1b's own territory) — chaining a field
+accessor onto THAT is asking to map a field over MANY entities at once,
+something no code path did before this, regardless of dot placement.
+Confirmed `Reference3.resolve_kind` already classified this shape as
+`METADATA_FIELD` correctly (via `terminal_functions`), so no change was
+needed there — the real gap was narrower than it first looked: `query()`
+producing N results instead of raising, and `_extract_data()` reading a
+field per result instead of only ever assuming one.
+
+David's own scope confirmation, given the analysis: build exactly the
+syntax he wrote (`:manifest():uuid()`, order-independent with future
+siblings, no dot needed), and explicitly keep the pre-existing
+`:name(...)+pointer` then `:uuid()`-in-`name_three` pattern (narrowing to
+ONE version, then reading its field) working unchanged — "different way
+to get a UUID, but should be equally valid." Confirmed via a dedicated
+test (`test_the_ordinary_name_three_field_accessor_position_still_works`)
+that this build did not touch that path at all.
+
+**What was built:**
+- `FilesReferenceFinder3._bare_manifest_field_call(name_one)` — new
+  `@staticmethod`, recognizes "name_one's path is a single, argument-less
+  `:manifest()` call, with exactly one chained function in
+  `name_one.functions` that is a registered field accessor (`SOURCE` is
+  not `None`)." Requires exactly one chained function deliberately — no
+  worked example has asked for stacking more than one field accessor on
+  this shape at once, so left unbuilt rather than guessed at. Reused
+  identically by `query()`, `_query_star_traversal()`, and
+  `_extract_data()` — one recognition helper, not three hand-rolled ones.
+- `query()` (literal root): new branch reading
+  `self.csvpaths.file_manager.get_manifest(root_major)` (the one named-
+  file's own manifest.json — every version/registration of THAT name),
+  building one `ReferenceResult3(path=e["file"], uuid=e["uuid"])` per
+  entry. Rejects combining with `name_three` (nothing left to narrow —
+  same reasoning `:fingerprint(...)`'s own bare-lookup shape already
+  uses).
+- `_query_star_traversal()`: new `elif` branch reading
+  `self.csvpaths.file_manager.files_root_manifest` (the global arrivals
+  ledger — Rule 1a's own resource for bare `:manifest()` at `'*'` root,
+  reused here rather than reassembling the same set by iterating every
+  name's own manifest separately). Ledger entries use different key names
+  than per-name manifest entries (confirmed by reading `FilesListener.
+  _prep_update()`: `"file_path"`/`"named_file_name"`, not `"file"` — a
+  real discrepancy that would have produced a `KeyError` if assumed
+  identical). Composes with `:regex()`-at-root_major's own `name_filter`
+  by matching each ledger entry's own `"named_file_name"` field, since the
+  ledger is a flat list, not organized by name.
+- `_extract_data()`'s `METADATA_FIELD` branch: widened the `is_bare_field_
+  call` path — when `_bare_definition_field_call()` finds nothing, now
+  also tries `_bare_manifest_field_call()` before giving up. Also widened
+  the manifest-fetch step to branch on `isinstance(reference.root_major,
+  Star3)`: `root_major` is the `'*'` token itself there, not a real name,
+  so `get_manifest(root_major)` cannot be called — reads
+  `files_root_manifest` instead in that case. Confirmed this branch was
+  previously unreachable for the ordinary name_three field-accessor shape
+  too (`_query_star_traversal()` has always unconditionally rejected
+  combining `'*'` traversal with a field accessor there), so widening it
+  here does not risk any pre-existing behavior.
+- `resolve()`/`resolve_from()` needed NO changes — confirmed by reading
+  them first: the existing `for result in results.results: result.data =
+  self._extract_data(result)` loop already turns "N query() results" into
+  "N resolved values" for any datatype, for free. The only genuinely new
+  work was producing real, multi-entry results in `query()`, and reading
+  the right field per result in `_extract_data()`.
+
+**Tests added** (`test_files_reference_finder_3.py`): `TestBareManifest
+FieldAccessor` (8 cases, literal root) covering one-result-per-entry,
+resolved values (not whole entries), David's own exact syntax, a second
+field (`:time()`) to prove genericity, name_three rejection, more-than-
+one-chained-function rejection, non-field-accessor (`:last()`) rejection,
+and the pre-existing name_three pattern staying unaffected;
+`TestStarBareManifestFieldAccessor` (4 cases, `'*'` root) covering the
+same shape against a dedicated `MANIFEST_FIELD_LEDGER` fixture (with the
+real `"file_path"`/`"named_file_name"` keys, not the simplified `LEDGER`
+fixture the existing ordinal-indexing tests use, which lacks them),
+`:regex()`-at-root_major composition, and name_three rejection. Full
+suite run twice, stable both times: 3148 passed, 11 failed (the known,
+unrelated SFTP/S3 failures requiring unset env vars — issue #216),
+identical both runs.
+
+**Deliberately not built**: `:all()`/`:flatten()`/`:groups()` combined
+with a chained field accessor — partitioning semantics differ per marker
+(one result vs. many, grouped vs. pooled), a distinct question from bare
+`:manifest()`'s "every entry, no partitioning" case, left on the bucket
+list.
+
+---
+
 ## `SELECTOR_WHEN_ARGUED` — declarative dual selector/value-accessor mechanism — BUILT 2026-08-28
 
 Replaces `FilesReferenceFinder3`'s original bespoke, hand-written

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -662,6 +662,67 @@ class TestStarTraversalFlatten:
             _star_finder("$*.files.*:last().v1").query()
 
 
+MANIFEST_FIELD_LEDGER = [
+    {
+        "named_file_name": "alpha",
+        "uuid": "u-ledger-1",
+        "file_path": "inputs/named_files/alpha/one.csv/bbb.csv",
+    },
+    {
+        "named_file_name": "beta",
+        "uuid": "u-ledger-2",
+        "file_path": "inputs/named_files/beta/two.csv/ddd.csv",
+    },
+]
+
+
+class TestStarBareManifestFieldAccessor:
+    # ':manifest():uuid()' during '*' traversal -- added 2026-08-28,
+    # David's own worked example ("get uuids from all registrations").
+    # Reads the global arrivals ledger (Rule 1a's own resource for bare
+    # ':manifest()' at '*' root), same as the literal-root shape reads
+    # its one named-file's own manifest.json.
+    def test_query_gives_one_result_per_ledger_entry(self):
+        results = _finder(
+            "$*.files.:manifest():uuid()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=MANIFEST_FIELD_LEDGER,
+        ).query()
+        assert set(results.uuids) == {"u-ledger-1", "u-ledger-2"}
+
+    def test_resolve_reads_the_field_off_each_ledger_entry(self):
+        results = _finder(
+            "$*.files.:manifest():uuid()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=MANIFEST_FIELD_LEDGER,
+        ).resolve()
+        assert {r.data for r in results.results} == {"u-ledger-1", "u-ledger-2"}
+
+    def test_composes_with_a_regex_name_filter_at_root_major(self):
+        results = _finder(
+            "$:regex(/^al.*/).files.:manifest():uuid()",
+            ALPHA_HOME,
+            ALPHA_MANIFEST,
+            inputs_files_path="inputs/named_files",
+            ledger=MANIFEST_FIELD_LEDGER,
+        ).query()
+        assert results.uuids == ["u-ledger-1"]
+
+    def test_combined_with_name_three_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.files.:manifest():uuid().:last()",
+                ALPHA_HOME,
+                ALPHA_MANIFEST,
+                inputs_files_path="inputs/named_files",
+                ledger=MANIFEST_FIELD_LEDGER,
+            ).query()
+
+
 class TestStarTraversalGroup:
     # bare ':all()' as name_one's entire content partitions every
     # named-file's EXACTLY-one-level matches (corrected 2026-08-12 to
@@ -1431,6 +1492,90 @@ class TestBareFingerprintLookup:
             "inputs/named_files/finn/backups/orders.csv/aaaa.csv",
         ]
         assert results.uuids == ["u-orders-1", "u-orders-backup-1"]
+
+
+class TestBareManifestFieldAccessor:
+    # ':manifest():uuid()'/':manifest():time()' -- added 2026-08-28,
+    # David's own worked examples ("get uuids from all registrations,"
+    # "get all acme registration uuids"). Unlike the ordinary field-
+    # accessor position (riding beside a real pointer in name_three,
+    # exactly one already-selected entity), this maps the chained field
+    # over EVERY entry in the matched named-file's own manifest.json --
+    # a genuinely different shape, not a syntax variant of the same
+    # thing.
+    def test_query_gives_one_result_per_manifest_entry(self):
+        results = _finder(
+            "$alpha.files.:manifest():uuid()", ALPHA_HOME, ALPHA_MANIFEST
+        ).query()
+        assert set(results.uuids) == {"u-zero-1", "u-one-1", "u-one-2"}
+
+    def test_resolve_gives_the_field_value_per_entry_not_the_whole_entry(self):
+        results = _finder(
+            "$alpha.files.:manifest():uuid()", ALPHA_HOME, ALPHA_MANIFEST
+        ).resolve()
+        assert {r.data for r in results.results} == {
+            "u-zero-1",
+            "u-one-1",
+            "u-one-2",
+        }
+        # every value is the plain uuid string, not the whole entry dict
+        assert all(isinstance(r.data, str) for r in results.results)
+
+    def test_single_entry_manifest_matches_davids_own_worked_example(self):
+        # the exact syntax from David's own worked examples
+        # ("$acme.files.:manifest():uuid()" -- get all acme registration
+        # uuids).
+        results = _finder(
+            "$acme.files.:manifest():uuid()", TEMPLATED_HOME, TEMPLATED_MANIFEST
+        ).resolve()
+        assert [r.data for r in results.results] == ["u-q2-1"]
+
+    def test_a_different_manifest_field_works_the_same_way(self):
+        # confirms this is a general mechanism, not hardcoded to :uuid()
+        # specifically -- STAR_ALPHA_MANIFEST's entries have a "time"
+        # field too.
+        results = _finder(
+            "$alpha.files.:manifest():time()", STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST
+        ).resolve()
+        assert {r.data for r in results.results} == {
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-02T00:00:00+00:00",
+            "2026-01-03T00:00:00+00:00",
+        }
+
+    def test_combined_with_name_three_is_not_yet_supported(self):
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.files.:manifest():uuid().:last()", ALPHA_HOME, ALPHA_MANIFEST
+            ).query()
+
+    def test_more_than_one_chained_function_is_not_recognized_here(self):
+        # falls through to the ordinary "functions attached directly to
+        # name_one" rejection -- picking one field per entry from more
+        # than one chained accessor at once is not a shape any worked
+        # example has asked for.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.files.:manifest():uuid():time()", ALPHA_HOME, ALPHA_MANIFEST
+            ).query()
+
+    def test_chaining_a_non_field_accessor_is_not_recognized_here(self):
+        # ':last()' is a POINTER, not a registered field accessor
+        # (SOURCE is None) -- falls through the same way.
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$alpha.files.:manifest():last()", ALPHA_HOME, ALPHA_MANIFEST
+            ).query()
+
+    def test_the_ordinary_name_three_field_accessor_position_still_works(self):
+        # David: narrowing to one version via :name(...)+pointer, then
+        # reading :uuid() in name_three, is a different, equally valid
+        # way to reach a uuid -- this new shape does not replace or
+        # touch it.
+        results = _finder(
+            '$alpha.files.:name("one.csv").:first():uuid()', ALPHA_HOME, ALPHA_MANIFEST
+        ).resolve()
+        assert results.results[0].data == "u-one-1"
 
 
 RANGE_HOME = "inputs/named_files/ranger"


### PR DESCRIPTION
## Summary

`$acme.files.:manifest():uuid()` and `$*.files.:manifest():uuid()` now
work, literal-root and `'*'` alike -- driven directly by David's own
worked examples ("get uuids from all registrations," "get all acme
registration uuids"), meant to combine with `SUBTRACT`/`INTERSECT`
against another reference expression.

## Background

Neither form worked before this PR. The first framing of the gap was
"does this need a `.` before the field accessor" -- traced live (parsing
both forms) and by code-reading before answering, since that turned out
to be the wrong axis. `:first():fingerprint()` (pointer + field accessor,
no dot, order-independent) already works today, but only because it
reads a field off exactly ONE already-selected entity. Bare `:manifest()`
does not select one entity -- it means "every entry in the manifest"
(Rule 1a/1b's own territory). Chaining a field accessor onto THAT asks
for something no code path did before: mapping a field over MANY entities
at once, regardless of dot placement.

`Reference3.resolve_kind` already classified this shape correctly as
`METADATA_FIELD` (confirmed live via `terminal_functions`), so the actual
gap was narrower than it first looked: `query()` needed to produce N
results instead of raising, and `_extract_data()` needed to read a field
per result instead of assuming exactly one.

## What changed

- `FilesReferenceFinder3._bare_manifest_field_call(name_one)` -- new
  shared recognition helper: "name_one's path is a single, argument-less
  `:manifest()` call, with exactly one chained field-accessor function."
  Reused identically by `query()`, `_query_star_traversal()`, and
  `_extract_data()`.
- `query()` (literal root): new branch reading the named-file's own
  `get_manifest()`, one `ReferenceResult3` per entry.
- `_query_star_traversal()`: new branch reading
  `files_root_manifest` (the global arrivals ledger, Rule 1a's own
  resource) -- confirmed its entries use different key names than
  per-name manifest entries (`"file_path"`/`"named_file_name"`, not
  `"file"`) by reading `FilesListener._prep_update()` directly, rather
  than assuming the two manifests share a shape. Composes with
  `:regex()`-at-root_major.
- `_extract_data()`: widened the `METADATA_FIELD` field-lookup to also
  try the new helper, and to read from `files_root_manifest` instead of
  `get_manifest(root_major)` when `root_major` is the `'*'` token (not a
  real name).
- `resolve()`/`resolve_from()`: **no changes needed** -- confirmed by
  reading them first that the existing per-result `_extract_data()` loop
  already turns N results into N resolved values for free.

The pre-existing `:name(...)+pointer`, then `:uuid()` in `name_three`
pattern (narrow to one version, then read its field) is untouched and
stays equally valid -- David's own explicit confirmation, covered by a
dedicated test.

Deliberately not built: `:all()`/`:flatten()`/`:groups()` combined with a
chained field accessor -- partitioning semantics differ per marker, a
distinct question left on the bucket list.

## Test plan

- [x] `TestBareManifestFieldAccessor` (8 cases, literal root): one result
      per entry, resolved values (not whole entries), David's own exact
      syntax, a second field (`:time()`) to prove genericity, name_three
      rejection, more-than-one-chained-function rejection, non-field-
      accessor rejection, pre-existing name_three pattern unaffected.
- [x] `TestStarBareManifestFieldAccessor` (4 cases, `'*'` root): same
      shape against a dedicated ledger fixture with the real
      `"file_path"`/`"named_file_name"` keys, `:regex()` composition,
      name_three rejection.
- [x] `tests/references/` full tree: 1555 passed.
- [x] Full suite run twice for stability: 3148 passed, 11 failed both
      times (identical) -- the known, unrelated SFTP/S3 failures
      requiring unset env vars (issue #216).

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
