### PR TITLE
Narrow :manifest() + chained field accessor for RESULTS run-level reads

### DIFF
--- a/csvpath/references/results_reference_finder_3.py
+++ b/csvpath/references/results_reference_finder_3.py
@@ -1157,9 +1157,46 @@ class ResultsReferenceFinder3(ReferenceFinder3):
                     "the run's own manifest on its own, without a "
                     "further instance selector."
                 )
-            return self._read_well_known_json(
+            entry = self._read_well_known_json(
                 Nos(result.path).join("manifest.json")
             )
+            manifest_field_call = self._find_field_function_call(name_one_calls)
+            if manifest_field_call is not None:
+                # ':manifest():named_file_uuid()'-style -- added
+                # 2026-08-28, David's own worked example ("get all the
+                # most recent acme registration uuids used in runs,"
+                # $*.results.:flatten():manifest():named_file_uuid()).
+                # Found by tracing, not guessed: this branch used to
+                # return the WHOLE manifest.json entry unconditionally
+                # the moment ':manifest()' was present anywhere in
+                # name_one_calls, even when a field accessor was ALSO
+                # chained alongside it -- never checking for one, so the
+                # narrowing silently never applied (no error, just the
+                # wrong shape of data back). :manifest() is not actually
+                # required for a run-level field read at all (see
+                # run_field_call's own branch just below, reached
+                # whenever :manifest() is ABSENT) -- it is legal but
+                # redundant here, the same "already reads the field off
+                # the matched entity, :manifest() adds nothing" relationship
+                # FILES' own :first():uuid() vs. :first():manifest():uuid()
+                # has. Reuses the identical extraction logic run_field_
+                # call's own branch below already has, just fed the
+                # entry already read above instead of re-reading it.
+                function_cls = ReferenceFunctionFactory.get_registered_class(
+                    manifest_field_call.name
+                )
+                key_path = function_cls.KEY.get(Reference3.RESULTS)
+                return self._extract_field_value_with_ledger_fallback(
+                    entry=entry,
+                    key_path=key_path,
+                    function_cls=function_cls,
+                    datatype=Reference3.RESULTS,
+                    ledger_entry_getter=lambda: self._find_archive_ledger_entry(
+                        ledger=self.csvpaths.results_manager.results_root_manifest,
+                        run_uuid=entry.get("run_uuid") if entry else None,
+                    ),
+                )
+            return entry
 
         run_field_call = self._find_field_function_call(name_one_calls)
         if run_field_call is not None:

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -256,32 +256,12 @@ and a stale-entry correction, are both done — see
   case.
 - `:having()` for RESULTS — **BUILT 2026-08-27**, see
   `deferred_work_done_list.md`.
-- **Found 2026-08-28, while checking David's own uuid-set-operation worked
-  examples (see the `SELECTOR_WHEN_ARGUED` entry above) — a silent-drop
-  risk, not just a missing feature.** `$*.results.:flatten():manifest()
-  :named_file_uuid()` (a content-accessor chain riding directly on
-  `:flatten()` in `name_one.functions`, no separating `.` before
-  `:manifest()`) does NOT raise. `_star_run_selector_chain()` recognizes
-  and exempts `:manifest()`/a field-accessor call from its own "unsupported
-  function" rejection — but its caller
-  (`_query_star_traversal`'s `_is_bare_function_only` branch) only ever
-  unpacks `(pointer, all_call, flatten_call, having_call)` from it, never
-  the recognized `manifest_call`/`field_call`. The `accessor` that
-  actually gets applied comes from a separate call,
-  `_name_three_selector(reference.name_three)`, which is `None` here since
-  nothing follows a `.` after `:flatten()`. Net effect: the query silently
-  returns the flattened, unreduced run list — NOT `named_file_uuid`
-  values — with no error telling the caller their accessor was ignored.
-  The shape that IS wired up correctly needs an explicit `.` before the
-  accessor chain (`$*.results.:flatten().:manifest():named_file_uuid()`,
-  routing it into `name_three`) — confirmed via live parse this puts the
-  calls in the right place, though the field itself
-  (`NamedFileUuid3`, `POSITIONS = {RESULTS: (NAME_ONE,)}`) has not been
-  end-to-end tested via this exact dotted path. Needs a decision: either
-  make the undotted shape actually apply the accessor it already
-  recognizes (matching what a user would naturally write), or make it
-  raise instead of silently dropping — silently ignoring recognized syntax
-  is worse than either.
+- **`:manifest()` combined with a chained field accessor in name_one
+  (e.g. `:manifest():named_file_uuid()`), silently returning the whole
+  manifest entry instead of narrowing to the field — BUILT 2026-08-28**,
+  see `deferred_work_done_list.md`. Turned out to be a general
+  `_extract_data()` bug, not `'*'`-traversal-specific — literal root had
+  the identical gap, just never exercised by a test.
 
 ## `'*'` traversal — FILES, essentially untouched by the recent RESULTS/CSVPATHS work
 

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,79 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## `:manifest()` combined with a chained field accessor, run-level (RESULTS) — BUILT 2026-08-28
+
+`$*.results.:flatten():manifest():named_file_uuid()` (David's own exact
+worked example, "get all the most recent acme registration uuids used in
+runs," meant to `INTERSECT` against the FILES-side uuid set built in the
+previous PR) now narrows to the field value, not the whole manifest
+entry.
+
+**Investigated before designing anything, not guessed.** The initial
+framing (from checking this while scoping the FILES fix, see the
+`SELECTOR_WHEN_ARGUED` and prior FILES `:manifest()` entries below) was
+"does the undotted shape need to be made to apply an accessor it
+currently discards, or should it raise." Traced through
+`_query_star_traversal()`'s bare-function-only branch,
+`_star_run_selector_chain()`, and `_extract_data()` in full before
+answering. Two things turned out to be true that the original framing
+had not accounted for:
+1. `_query_star_traversal()` and `_star_run_selector_chain()` were
+   already fine — `_star_run_selector_chain()` already exempts
+   `:manifest()`/a field-accessor call from its "unsupported function"
+   rejection, and `query()` already produces real, per-run results (an
+   unreduced pool) regardless. Nothing needed changing there.
+2. The actual bug lived entirely in `_extract_data()`, and it is NOT
+   `'*'`-traversal-specific — the exact same bug exists for the literal-
+   root shape too (`$acme.results.customers/2025:first():manifest()
+   :named_file_uuid()`), just never exercised by any existing test.
+   `_extract_data()`'s `has_manifest` branch returned the WHOLE
+   `manifest.json` entry the moment `:manifest()` was present ANYWHERE in
+   `name_one_calls` (`has_manifest = any(seg.contains_function_named
+   ("manifest") for seg in name_one_calls ...)`), unconditionally,
+   BEFORE ever checking whether a field accessor was ALSO chained
+   alongside it to narrow further — the `run_field_call` branch just
+   below it that DOES do that narrowing was structurally unreachable
+   whenever `:manifest()` was also present, since the `has_manifest`
+   branch always returns first.
+
+Also confirmed, before building: `:manifest()` is not actually required
+for a run-level field read at all — `$*.results.:flatten()
+:named_file_uuid()` (no `:manifest()`) already worked correctly before
+this PR, via the pre-existing `run_field_call` branch, the exact same
+"already reads the field off the matched entity, `:manifest()` adds
+nothing" relationship the previous FILES PR's `:first():uuid()` vs.
+`:first():manifest():uuid()` distinction already established. `:manifest()`
+chained alongside a field accessor is legal but redundant, not a
+different, narrower shape needing its own separate design.
+
+**What was built:** widened `_extract_data()`'s `has_manifest` branch
+(shared by literal-root and `'*'`-root alike, since both funnel through
+the same method) to check for a field accessor in `name_one_calls`
+(reusing `_find_field_function_call()`, already used by the sibling
+`run_field_call` branch) after reading the entry, and — if one is
+present — narrow to that field using the identical extraction logic
+(`function_cls.KEY`, `_extract_field_value_with_ledger_fallback()`) the
+`run_field_call` branch already has, instead of returning the whole
+entry. Bare `:manifest()` with no field accessor keeps its own pre-
+existing behavior unchanged (confirmed via a dedicated regression test).
+Order-independence (`:named_file_uuid():manifest()` meaning the same as
+`:manifest():named_file_uuid()`) confirmed too, matching the same
+convention the ordinary pointer+field-accessor position already has.
+
+**Tests added** (`test_results_reference_finder_3.py`, in
+`TestStarTraversalFlatten`'s own class): narrowing works for `'*'` root
+with multiple pooled runs (no pointer, matching David's own syntax
+exactly); bare `:manifest()` alone still gives the whole entry
+(regression check); field-accessor-before-`:manifest()` order also
+works; the literal-root shape gets the same fix (not `'*'`-specific);
+combining with `name_three` still correctly raises. Full suite run
+twice, stable both times: 3153 passed, 11 failed (the known, unrelated
+SFTP/S3 failures requiring unset env vars — issue #216), identical both
+runs.
+
+---
+
 ## Bare `:manifest()` combined with a chained field accessor (FILES) — BUILT 2026-08-28
 
 `$acme.files.:manifest():uuid()`/`$*.files.:manifest():uuid()` now work,

--- a/tests/references/test_results_reference_finder_3.py
+++ b/tests/references/test_results_reference_finder_3.py
@@ -523,6 +523,112 @@ class TestFlatten:
         assert results.results[0].uuid == "deep-uuid"
         assert results.results[0].data == "acme"
 
+    def test_manifest_combined_with_a_field_accessor_narrows_not_whole_entry(
+        self, tmp_path
+    ):
+        # added 2026-08-28 -- David's own worked example ("get all the
+        # most recent acme registration uuids used in runs"),
+        # $*.results.:flatten():manifest():named_file_uuid(). Found by
+        # tracing (not guessed): _extract_data()'s own has_manifest
+        # branch used to return the WHOLE manifest.json entry the moment
+        # ':manifest()' was present anywhere in name_one, even with a
+        # field accessor ALSO chained alongside it -- it never checked
+        # for one, so the narrowing silently never applied. No pointer
+        # here (matches David's own syntax exactly) -- every matched run
+        # comes back, each narrowed to its own named_file_uuid value.
+        run1 = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "run1-uuid", {}
+        )
+        _write_json(
+            Path(run1) / "manifest.json",
+            {"run_uuid": "run1-uuid", "named_file_uuid": "file-uuid-1"},
+        )
+        run2 = _make_run(
+            tmp_path / "acme", "2026-01-02_00-00-00", "run2-uuid", {}
+        )
+        _write_json(
+            Path(run2) / "manifest.json",
+            {"run_uuid": "run2-uuid", "named_file_uuid": "file-uuid-2"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1, run2])
+        results = _finder(
+            "$*.results.:flatten():manifest():named_file_uuid()", str(tmp_path)
+        ).resolve()
+        assert {r.data for r in results.results} == {"file-uuid-1", "file-uuid-2"}
+        # not the whole dict -- confirms narrowing actually happened,
+        # not just that no error was raised.
+        assert all(isinstance(r.data, str) for r in results.results)
+
+    def test_manifest_alone_with_no_field_accessor_still_gives_the_whole_entry(
+        self, tmp_path
+    ):
+        # regression check -- ':manifest()' bare (no field accessor
+        # chained) must keep its own pre-existing, already-shipped
+        # behavior unchanged.
+        run1 = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "run1-uuid", {}
+        )
+        _write_json(
+            Path(run1) / "manifest.json",
+            {"run_uuid": "run1-uuid", "named_file_uuid": "file-uuid-1"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        results = _finder(
+            "$*.results.:flatten():manifest()", str(tmp_path)
+        ).resolve()
+        assert results.results[0].data == {
+            "run_uuid": "run1-uuid",
+            "named_file_uuid": "file-uuid-1",
+        }
+
+    def test_field_accessor_order_before_manifest_also_works(self, tmp_path):
+        # order-independence, same as the ordinary pointer+field-
+        # accessor position already has -- ':named_file_uuid():manifest()'
+        # means the same thing as ':manifest():named_file_uuid()'.
+        run1 = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "run1-uuid", {}
+        )
+        _write_json(
+            Path(run1) / "manifest.json",
+            {"run_uuid": "run1-uuid", "named_file_uuid": "file-uuid-1"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        results = _finder(
+            "$*.results.:flatten():named_file_uuid():manifest()", str(tmp_path)
+        ).resolve()
+        assert results.results[0].data == "file-uuid-1"
+
+    def test_literal_root_also_gets_the_narrowing_fix(self, tmp_path):
+        # confirms this is not '*'-traversal-specific -- the bug lived
+        # in _extract_data(), shared by every root_major shape.
+        base = tmp_path / "acme" / "customers" / "2025"
+        run1 = _make_run(base, "2026-01-01_00-00-00", "run1-uuid", {})
+        _write_json(
+            Path(run1) / "manifest.json",
+            {"run_uuid": "run1-uuid", "named_file_uuid": "file-uuid-1"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        results = _finder(
+            "$acme.results.customers/2025:first():manifest():named_file_uuid()",
+            str(tmp_path),
+        ).resolve()
+        assert results.results[0].data == "file-uuid-1"
+
+    def test_combined_with_name_three_is_not_supported(self, tmp_path):
+        run1 = _make_run(
+            tmp_path / "acme", "2026-01-01_00-00-00", "run1-uuid", {"orders": "o1"}
+        )
+        _write_json(
+            Path(run1) / "manifest.json",
+            {"run_uuid": "run1-uuid", "named_file_uuid": "file-uuid-1"},
+        )
+        _write_archive_manifest(tmp_path, "acme", [run1])
+        with pytest.raises(ReferenceException3):
+            _finder(
+                "$*.results.:flatten():manifest():named_file_uuid().orders",
+                str(tmp_path),
+            ).resolve()
+
     def test_all_grouping_partitions_by_composite_group_and_template_key(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

`$*.results.:flatten():manifest():named_file_uuid()` -- David's own exact
worked example (meant to `INTERSECT` against the FILES-side uuid set from
the previous PR) -- now resolves to the field value, not the whole
manifest.json entry.

## Background

The original framing was "does the undotted shape need to be made to
apply an accessor it currently discards, or should it raise." Traced
through `_query_star_traversal()`, `_star_run_selector_chain()`, and
`_extract_data()` in full before answering, rather than assuming either
diagnosis. Two things turned out different from the original framing:

1. `_query_star_traversal()`/`_star_run_selector_chain()` were already
   fine -- `_star_run_selector_chain()` already exempts `:manifest()`/a
   field accessor from its "unsupported function" rejection, and
   `query()` already produces real, per-run results regardless. Nothing
   needed changing there.
2. The actual bug lived entirely in `_extract_data()`, and it is **not**
   `'*'`-traversal-specific -- the identical bug affects the literal-root
   shape too (`$acme.results.customers/2025:first():manifest()
   :named_file_uuid()`), just never exercised by any existing test.
   `_extract_data()`'s `has_manifest` branch returned the whole
   `manifest.json` entry the moment `:manifest()` was present anywhere in
   `name_one_calls`, unconditionally -- before ever checking whether a
   field accessor was also chained alongside it. The `run_field_call`
   branch that already does that narrowing, just below it, was
   structurally unreachable whenever `:manifest()` was also present.

Also confirmed before building: `:manifest()` is not actually required
for a run-level field read at all -- `$*.results.:flatten()
:named_file_uuid()` (no `:manifest()`) already worked correctly before
this PR, via the pre-existing `run_field_call` branch. `:manifest()`
chained alongside a field accessor is legal but redundant, the same
relationship the previous FILES PR's `:first():uuid()` vs.
`:first():manifest():uuid()` distinction already established -- not a
different, narrower shape needing its own separate design.

## What changed

Widened `_extract_data()`'s `has_manifest` branch (shared by literal-root
and `'*'`-root, both funnel through the same method) to check for a field
accessor in `name_one_calls` after reading the entry, and -- if present
-- narrow to that field using the identical extraction logic
(`function_cls.KEY`, `_extract_field_value_with_ledger_fallback()`) the
sibling `run_field_call` branch already has, instead of returning the
whole entry. Bare `:manifest()` with no field accessor is unchanged.

## Test plan

- [x] `'*'` root: narrowing works with multiple pooled runs, no pointer
      (matches David's own syntax exactly).
- [x] Regression: bare `:manifest()` alone still gives the whole entry.
- [x] Field-accessor-before-`:manifest()` order also works
      (order-independence).
- [x] Literal-root shape gets the identical fix.
- [x] Combining with `name_three` still correctly raises.
- [x] `tests/references/` full tree: 1560 passed.
- [x] Full suite run twice for stability: 3153 passed, 11 failed both
      times (identical) -- the known, unrelated SFTP/S3 failures
      requiring unset env vars (issue #216).

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
