### PR TITLE
Allow a field accessor alongside FILES' :all()/:groups() GROUP-mode pointer

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -511,20 +511,41 @@ class FilesReferenceFinder3(ReferenceFinder3):
         # has_range cover the complete set of name_three-legal FILES
         # functions), so at least one of them is always true here.
 
-        if partitioned and (has_range or (pointers and (has_manifest or has_field_function))):
-            # mirrors ResultsReferenceFinder3's own ':all()'-grouping
-            # restriction (settled 2026-08-11 there): grouping (one-
-            # level ':all()' or any-depth ':groups()') plus :manifest()/
-            # a field-accessor is an under-specified interaction, not
-            # decided -- resolve the grouped versions on their own
-            # first, rather than guessing what "the manifest entry of
-            # every group's own latest version, all at once" should even
-            # resolve to.
+        if partitioned and (has_range or (pointers and has_manifest)):
+            # narrowed 2026-08-29 -- this used to also reject
+            # `has_field_function`, but that was stale relative to
+            # ResultsReferenceFinder3's OWN, later-refined precedent:
+            # RESULTS' _star_group_and_reduce() only rejects a name_three
+            # CONTENT accessor (:errors()/:vars()/etc.) here, explicitly
+            # NOT a field accessor (e.g. ":all():last().invoices:uuid()"
+            # resolves fine there, confirmed live before that code was
+            # written -- poolable, one result per matched group). This
+            # comment used to claim FILES "mirrors" that RESULTS
+            # restriction, but it mirrored RESULTS' ORIGINAL, blanket
+            # 2026-08-11 rejection, before RESULTS' own later split --
+            # FILES was never updated to match. :manifest() (a whole-
+            # resource read) stays rejected here for the same reason it
+            # always was: "the manifest entry of every group's own latest
+            # version, all at once" is still Rule 1 territory (each
+            # group's own single reduced candidate is fine on its own,
+            # but pooling several groups' own whole entries together
+            # is not obviously the same "resolve one entity" contract).
+            # A field accessor is exempt from Rule 1 everywhere else in
+            # this file (see the `selected_candidates`/`ambiguous_
+            # content_read` comments just below, already correctly
+            # written to only flag `has_manifest`) -- this early check
+            # was the one place still treating the two the same.
+            #
+            # The reduction logic just below already does exactly the
+            # right thing once this stops blocking it: `partitioned`
+            # already reduces each distinct file_home's own candidates
+            # independently via the pointer, before a field accessor (or
+            # :manifest()'s own entry) is ever read -- no new machinery
+            # needed here, only removing the premature rejection.
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support combining "
-                "':all()'/':groups()' grouping with :manifest() or a "
-                "field-accessor function -- resolve the grouped versions "
-                "on their own first."
+                "':all()'/':groups()' grouping with :manifest() -- "
+                "resolve the grouped versions on their own first."
             )
 
         if has_range:

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -301,9 +301,13 @@ and a stale-entry correction, are both done — see
   combined with a chained field accessor is a related but distinct
   question (partitioning semantics differ per marker), still open, just
   below.
-- FILES' `:all()`/`:groups()` (GROUP modes) combined with `:manifest()`/
-  a field-accessor — same single-entity-vs-grouping restriction RESULTS'
-  `name_three` content accessor now has, not yet built for FILES.
+- FILES' `:all()`/`:groups()` (GROUP modes) combined with a chained field
+  accessor (e.g. `:all().:last():uuid()`) — **BUILT 2026-08-29**, see
+  `deferred_work_done_list.md`. `:manifest()` (whole-resource) combined
+  with GROUP modes stays rejected, unchanged — only the field-accessor
+  half of this item was ever under-specified; RESULTS had already
+  settled the field-accessor case, FILES just hadn't been updated to
+  match.
 - A literal prefix *before* `:flatten()` for FILES — **BUILT 2026-08-27**,
   see `deferred_work_done_list.md`.
 - FILES' `:from()`/`:to()` combined with `:all()`/`:groups()` grouping in

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,77 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## FILES' `:all()`/`:groups()` GROUP-mode combined with a chained field accessor — BUILT 2026-08-29
+
+`$acme.files.:all().:last():uuid()`/`$mixed.files.:groups().:last():uuid()`
+now resolve to one field value per (named-file, path) group instead of
+raising.
+
+**Investigated before designing anything, not guessed.** The bucket-list
+entry read as a single, still-open question — "GROUP modes combined with
+`:manifest()`/a field-accessor... not yet built for FILES." Traced
+`query()`'s own GROUP-mode rejection (`if partitioned and (has_range or
+(pointers and (has_manifest or has_field_function))): raise`) and the
+reduction logic just below it before touching anything, and found the
+rejection was stricter than the code actually needed to be:
+- The reduction logic just below (`if pointers: if partitioned: ...`)
+  already independently reduces each distinct `file_home`'s own
+  candidates via the pointer, unconditionally — nothing about that logic
+  depends on whether `has_manifest`/`has_field_function` is also present.
+  `ReferenceResults3.ambiguous_content_read` was already correctly
+  written to flag ONLY `has_manifest`, never `has_field_function` (`has_
+  manifest and len(selected_candidates) > 1`) — the Rule-1-vs-Rule-3
+  (whole-resource vs. poolable-field) distinction this whole class of fix
+  depends on was already present, just not consistently applied.
+- The rejection's own comment claimed it "mirrors ResultsReferenceFinder3's
+  own `:all()`-grouping restriction (settled 2026-08-11 there)" — but
+  RESULTS' restriction was later refined and FILES was never updated to
+  match. RESULTS' actual, current `_star_group_and_reduce()` only rejects
+  a name_three CONTENT accessor (`:errors()`/`:vars()`/etc.) when
+  GROUP-mode partitioning combines with a pointer — a field accessor
+  (e.g. `":all():last().invoices:uuid()"`) is explicitly NOT rejected
+  there, confirmed live before that RESULTS code was even written. FILES'
+  comment was citing RESULTS' original, since-superseded blanket
+  rejection, not its current behavior — a real, confirmable staleness,
+  not a guess (the same class of drift the "cross-datatype function
+  consistency" principle exists to catch).
+- `_extract_data()` needed NO changes at all — the newly-reachable shape
+  (`:all().:last():uuid()`) routes `:uuid()` through `name_three`, the
+  same ordinary, already-tested field-accessor extraction path every
+  other `name_three` field accessor already uses. Confirmed by parsing
+  the exact reference live before writing any code: `:all()`/`:groups()`
+  bare occupies name_one's entire content by construction (`is_bare_all_
+  reference`/`is_bare_groups_reference` both require `not name_one.
+  functions`), so the trailing `:last():uuid()` has nowhere to land
+  except name_three — there is no alternate, name_one.functions-based
+  variant of this shape the way the two previous `:manifest()`+field-
+  accessor fixes needed to handle.
+
+**What was built:** narrowed `query()`'s GROUP-mode rejection from
+`pointers and (has_manifest or has_field_function)` to `pointers and
+has_manifest` — `:manifest()` (whole-resource) stays rejected in this
+position, unchanged, for the same Rule-1 reasoning it always had; a field
+accessor is no longer caught by the same check. No other code changes
+were needed anywhere.
+
+**Tests updated** (`test_files_reference_finder_3.py`): the two existing
+tests asserting the OLD field-accessor rejection
+(`test_all_combined_with_a_field_accessor_is_not_yet_supported`,
+`test_groups_combined_with_a_field_accessor_is_not_yet_supported`) were
+converted to positive assertions confirming one correct uuid per group
+(`ALPHA_MANIFEST`'s two file_home groups; `MIXED_MANIFEST`'s two
+different-depth groups). Their `:manifest()`-combined sibling tests
+(asserting the still-correct rejection) were left unchanged. `'*'`-
+traversal's own, separate and much broader field-accessor rejection in
+`_query_star_traversal()` (a bigger, still-open gap, unrelated to this
+fix's `partitioned`-plus-`pointers` scope) was not touched — confirmed
+its own existing tests (`_star_finder`/`_flatten_star_finder`-based)
+still pass unchanged. Full suite run twice, stable both times: 3153
+passed, 11 failed (the known, unrelated SFTP/S3 failures requiring unset
+env vars — issue #216), identical both runs.
+
+---
+
 ## `:manifest()` combined with a chained field accessor, run-level (RESULTS) — BUILT 2026-08-28
 
 `$*.results.:flatten():manifest():named_file_uuid()` (David's own exact

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -1031,11 +1031,18 @@ class TestAllForOneNamedFile:
                 "$alpha.files.:all().:last():manifest()", ALPHA_HOME, ALPHA_MANIFEST
             ).query()
 
-    def test_all_combined_with_a_field_accessor_is_not_yet_supported(self):
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$alpha.files.:all().:last():uuid()", ALPHA_HOME, ALPHA_MANIFEST
-            ).query()
+    def test_all_combined_with_a_field_accessor_gives_one_value_per_group(self):
+        # narrowed 2026-08-29 -- unlike ':manifest()' (a whole-resource
+        # read, still Rule 1 territory), a field accessor is poolable:
+        # each file_home group's own pointer-reduced candidate
+        # contributes its own field value. Matches
+        # ResultsReferenceFinder3's own already-settled precedent for
+        # the identical shape (a field accessor riding alongside a
+        # pointer during GROUP-mode partitioning is not rejected there).
+        results = _finder(
+            "$alpha.files.:all().:last():uuid()", ALPHA_HOME, ALPHA_MANIFEST
+        ).resolve()
+        assert {r.data for r in results.results} == {"u-zero-1", "u-one-2"}
 
 
 class TestFlattenForOneNamedFile:
@@ -1709,11 +1716,14 @@ class TestGroupsForOneNamedFile:
                 "$mixed.files.:groups().:last():manifest()", MIXED_HOME, MIXED_MANIFEST
             ).query()
 
-    def test_groups_combined_with_a_field_accessor_is_not_yet_supported(self):
-        with pytest.raises(ReferenceException3):
-            _finder(
-                "$mixed.files.:groups().:last():uuid()", MIXED_HOME, MIXED_MANIFEST
-            ).query()
+    def test_groups_combined_with_a_field_accessor_gives_one_value_per_group(self):
+        # narrowed 2026-08-29, same fix as ':all()' above -- ':groups()'
+        # (any-depth GROUP) shares the identical `partitioned` reduction
+        # path.
+        results = _finder(
+            "$mixed.files.:groups().:last():uuid()", MIXED_HOME, MIXED_MANIFEST
+        ).resolve()
+        assert {r.data for r in results.results} == {"u-zero-2", "u-deep-2"}
 
 
 class TestManifestCombinedWithNameThree:


### PR DESCRIPTION
## Summary

`$acme.files.:all().:last():uuid()` and `$mixed.files.:groups().:last():uuid()`
now resolve to one field value per (named-file, path) group, instead of
raising.

## Background

The bucket-list entry read as a single, still-open question -- "GROUP
modes combined with `:manifest()`/a field-accessor... not yet built for
FILES." Traced `query()`'s own GROUP-mode rejection and the reduction
logic just below it before touching anything, rather than assuming the
whole thing needed new machinery:

- The reduction logic (`if pointers: if partitioned: ...`) already
  independently reduces each distinct `file_home`'s own candidates via
  the pointer, unconditionally -- nothing about it depends on whether
  `:manifest()`/a field accessor is also present.
  `ReferenceResults3.ambiguous_content_read` was already correctly
  written to flag only `has_manifest`, never `has_field_function` -- the
  Rule-1-vs-Rule-3 (whole-resource vs. poolable-field) distinction this
  fix depends on already existed, just wasn't consistently applied.
- The rejection's own comment claimed it "mirrors"
  `ResultsReferenceFinder3`'s own `:all()`-grouping restriction -- but
  that was citing RESULTS' *original*, since-superseded blanket
  rejection. RESULTS' current `_star_group_and_reduce()` already allows a
  field accessor through here (e.g. `":all():last().invoices:uuid()"`
  resolves fine there, confirmed live before that code was even
  written), only rejecting a whole-resource content accessor. FILES had
  simply never been updated to match -- a real, confirmable staleness,
  not a guess.
- `_extract_data()` needed **no changes at all** -- `:all()`/`:groups()`
  bare occupies name_one's entire content by construction, so the
  trailing field accessor has nowhere to land except `name_three`, the
  same already-tested extraction path every other `name_three` field
  accessor already uses.

## What changed

Narrowed `query()`'s GROUP-mode rejection from `pointers and
(has_manifest or has_field_function)` to `pointers and has_manifest` --
`:manifest()` (whole-resource) stays rejected here, unchanged, for the
same Rule-1 reasoning it always had; a field accessor is no longer caught
by the same check. That is the entire fix.

Deliberately out of scope: `'*'`-traversal's own, separate and much
broader field-accessor rejection in `_query_star_traversal()` -- a
bigger, still-open gap, unrelated to this fix's `partitioned`-plus-
`pointers` scope. Confirmed its own existing tests still pass unchanged.

## Test plan

- [x] Converted the two existing tests that asserted the old rejection
      into positive assertions -- one correct uuid per group, for both
      `:all()` (`ALPHA_MANIFEST`'s two file_home groups) and `:groups()`
      (`MIXED_MANIFEST`'s two different-depth groups).
- [x] Their `:manifest()`-combined sibling tests (asserting the
      still-correct rejection) left unchanged.
- [x] `tests/references/` full tree: 1560 passed.
- [x] Full suite run twice for stability: 3153 passed, 11 failed both
      times (identical) -- the known, unrelated SFTP/S3 failures
      requiring unset env vars (issue #216).

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
