### PR TITLE
Allow a field accessor alongside FILES' '*'-traversal pointer

### DIFF
--- a/csvpath/references/files_reference_finder_3.py
+++ b/csvpath/references/files_reference_finder_3.py
@@ -652,12 +652,31 @@ class FilesReferenceFinder3(ReferenceFinder3):
           -- one result per (named-file, path) pair regardless of how
           deep that pair's own path happens to be.
 
-        Deliberately narrow for now, matching only the spec's own worked
-        examples: combining '*'/':flatten()'/':groups()' traversal with
-        :manifest()/a field-accessor function in name_three is not yet
-        supported -- those all assume exactly one already-known manifest
-        to re-read in _extract_data(), which does not hold when a result
-        could have come from any of several named-files' manifests.
+        A field accessor (e.g. :uuid()) riding alongside the pointer in
+        name_three is supported (narrowed 2026-08-29, matching FILES'
+        own literal-root GROUP-mode fix the same day, and RESULTS' own
+        long-settled precedent for the identical shape) -- poolable, one
+        value per matched candidate, exempt from Rule 1 (manifest_field_
+        functions_proposal.md's "Entity resolution and pooling"
+        section) the same way it is everywhere else in this file.
+        _extract_data() already resolves this correctly for a Star3
+        root_major via the global arrivals ledger (added 2026-08-28,
+        alongside FILES' own bare ':manifest():field()' shape -- same
+        Star3-aware branch, reused here for free since it keys off
+        `field_call` generically, not off which grammar position found
+        it).
+
+        :manifest() (a whole-resource read) STAYS rejected here,
+        deliberately -- not because _extract_data() cannot resolve it
+        (it can, via that same Star3-aware ledger branch, already used
+        by Rule 1b's own :manifest()-with-a-global-pointer shape), but
+        because this method's own return here sets no `ambiguous_
+        content_read` flag at all: GROUP mode (':all()'/':groups()') can
+        legitimately produce more than one reduced candidate (one per
+        file_home group), and resolving each one's own WHOLE manifest
+        entry at once is exactly the Rule 1 violation that flag exists
+        to catch elsewhere -- adding it here, correctly, is its own
+        separate piece of work, not bundled into this fix.
 
         ':home()' and ':definition()' as name_one's own content -- added
         2026-08-27 (FILES '*' traversal generalization bucket-list
@@ -836,16 +855,15 @@ class FilesReferenceFinder3(ReferenceFinder3):
             )
         built = self._build_chain(name_three.functions)
         pointers = [f for f in built if f.ROLE == Function3.POINTER]
-        unsupported = (
-            any(f.name == "manifest" for f in built)
-            or self._find_field_function_call(built) is not None
-        )
-        if unsupported:
+        if any(f.name == "manifest" for f in built):
+            # narrowed 2026-08-29 -- a field accessor is no longer
+            # caught by this check, see the method's own docstring for
+            # why :manifest() alone still is.
             raise ReferenceException3(
                 "FilesReferenceFinder3 does not yet support combining '*' "
-                "traversal with :manifest() or a field-accessor function -- "
-                "only a plain pointer (:first()/:last()/:index(n)) is "
-                "supported so far."
+                "traversal with :manifest() -- only a plain pointer "
+                "(:first()/:last()/:index(n)), optionally with a field "
+                "accessor, is supported so far."
             )
         if not pointers:
             raise ReferenceException3(

--- a/specs/references_v3/notes/deferred_work_bucket_list.md
+++ b/specs/references_v3/notes/deferred_work_bucket_list.md
@@ -265,15 +265,15 @@ and a stale-entry correction, are both done — see
 
 ## `'*'` traversal — FILES, essentially untouched by the recent RESULTS/CSVPATHS work
 
-- `FilesReferenceFinder3`'s own `_query_star_traversal()` still rejects
-  combining `'*'` traversal with `:manifest()`/a field-accessor function
-  outright (`:definition()` is now the one exception, see below) — the
-  same class of gap RESULTS/CSVPATHS just had fixed (field accessors,
-  then `:having()`/`:flatten()`/`:all()`, then path narrowing/`name_three`,
-  then pointer optionality), never applied to FILES otherwise. FILES'
-  traversal already never requires a pointer (confirmed — no fix needed
-  there), but everything else in that generalization sequence hasn't been
-  revisited for this datatype.
+- `FilesReferenceFinder3`'s own `_query_star_traversal()` combining `'*'`
+  traversal with a field accessor riding beside the pointer in
+  `name_three` (POOL and GROUP modes alike) — **BUILT 2026-08-29**, see
+  `deferred_work_done_list.md`. `:manifest()` (whole-resource) still
+  stays rejected here, deliberately — GROUP mode can legitimately
+  produce more than one reduced candidate, and this method sets no
+  `ambiguous_content_read` flag to catch resolving several whole entries
+  at once (Rule 1); adding that flag correctly is its own separate,
+  still-open piece of work, not bundled into this fix.
 
 - **Concrete worked example that drove this (David, 2026-08-21)**: "which
   named-files have `on_arrival` set" needs `$*.files.:home():definition

--- a/specs/references_v3/notes/deferred_work_done_list.md
+++ b/specs/references_v3/notes/deferred_work_done_list.md
@@ -9,6 +9,79 @@ the way it was is often exactly what the next person touching it needs.
 
 ---
 
+## FILES' `_query_star_traversal()` combined with a chained field accessor (POOL and GROUP alike) — BUILT 2026-08-29
+
+`$*.files.*.:last():uuid()` (POOL), `$*.files.:all().:last():uuid()`
+(GROUP, one level), and `$*.files.:groups().:last():uuid()`/
+`$*.files.:flatten().:last():uuid()` (any depth, GROUP/POOL) all now
+work, instead of raising. Found and fixed the same day as, and directly
+motivated by, the literal-root GROUP-mode fix just above — same class of
+gap, one level broader (every `'*'`-traversal shape, not just the
+literal-root one).
+
+**Investigated before designing anything, not guessed.** `_query_star_
+traversal()`'s shared name_three-processing tail had a single, blanket
+`unsupported = has_manifest OR field_accessor` check covering EVERY
+traversal shape (POOL and GROUP, one-level and any-depth alike) — even
+broader than the literal-root check the previous fix narrowed. Traced the
+reduction logic just below it (`if pointers: if partitioned: ...`)
+before touching anything: it already independently reduces each
+`file_home`'s own candidates in GROUP mode, or pools to one overall
+candidate in POOL mode, regardless of which accessor rides alongside the
+pointer — nothing there needed to change either.
+
+The one genuinely new question this fix raised (not present in the
+literal-root case): `_extract_data()`'s Star3-aware branch (added
+2026-08-28, previously only exercised by the bare `:manifest():field()`-
+in-name_one shape) reads the GLOBAL arrivals ledger to re-derive a
+matched candidate's own field, since `result.uuid` alone does not say
+which named-file a `'*'`-traversal candidate came from. Confirmed this
+generalizes correctly to a `name_three`-sourced `field_call` too (not
+just the name_one-sourced one it was built for) by reading `_extract_
+data()`'s own control flow: the Star3 branch lives inside `if field_call
+is not None:`, shared by both sources — no code change needed there
+either, only test fixtures needed a ledger they never previously
+required (see below).
+
+**What was built:** narrowed the shared `unsupported` check to `has_
+manifest` only, mirroring the literal-root fix exactly. `:manifest()`
+(whole-resource) stays rejected for every `'*'`-traversal shape,
+deliberately — same Rule 1 reasoning as the literal-root fix (GROUP mode
+can produce more than one reduced candidate; this method sets no
+`ambiguous_content_read` flag), restated in the method's own docstring
+and per-test comments rather than left to go stale silently the way the
+original comment did (see below). POOL mode (`:flatten()` and the plain
+`'*'`/prefixed shapes) always reduces to exactly one overall candidate,
+so `:manifest()` there has no real Rule-1 ambiguity risk either — kept
+rejected anyway, for consistency, rather than carving out a POOL-only
+exception no worked example has asked for.
+
+**A stale comment corrected in the process**: the method's own docstring,
+and two per-test comments, used to claim the restriction existed because
+"`root_major` is `'*'` here, so `_extract_data()` cannot know which
+named-file's manifest to re-read" — no longer true (the Star3-aware
+ledger branch already solves exactly that, added 2026-08-28) and, on
+closer inspection, was never really the FULL reason even before that —
+the real, still-current reason `:manifest()` stays rejected is Rule 1
+(the ambiguous-multiple-whole-entries risk), not a technical limitation.
+Rewritten to state that accurately rather than leaving the old
+explanation to mislead the next person who reads it.
+
+**Tests updated/added** (`test_files_reference_finder_3.py`): the one
+existing test asserting the old field-accessor rejection (POOL mode,
+`TestStarTraversalFlatten`) converted to a positive assertion; three new
+tests added for shapes that were never testable before (GROUP one-level,
+GROUP any-depth, POOL any-depth). `STAR_LEDGER`/`FLATTEN_LEDGER` fixtures
+added — `_star_finder`/`_flatten_star_finder` never needed a ledger
+before this fix, since the shapes reaching it were always rejected;
+every OTHER star-traversal test in this file still does not read it.
+`:manifest()`-combined tests (asserting the still-correct rejection)
+left unchanged in every mode. Full suite run twice, stable both times:
+3156 passed, 11 failed (the known, unrelated SFTP/S3 failures requiring
+unset env vars — issue #216), identical both runs.
+
+---
+
 ## FILES' `:all()`/`:groups()` GROUP-mode combined with a chained field accessor — BUILT 2026-08-29
 
 `$acme.files.:all().:last():uuid()`/`$mixed.files.:groups().:last():uuid()`

--- a/specs/references_v3/spec/references_v3_compendium.md
+++ b/specs/references_v3/spec/references_v3_compendium.md
@@ -591,6 +591,28 @@ set of groupings:
     :identity(), etc.) is undeclared, for now, and falls back to
     exact-accessor-equality required for value comparison
 
+#### Using UUID in set operations as an example of field comparisons
+First two simple examples:
+- Get uuids from all registrations
+`$*.files.:manifest():uuid()`
+- Get all acme registration uuids
+`$acme.files.:manifest():uuid()`
+
+Now two example set operations that match/join on fields, UUID in this case.
+- Get all registration UUIDs, except those of the acme named-files
+```
+$*.files.:manifest():uuid()
+SUBTRACT
+$acme.files.:manifest():uuid()
+```
+
+- Get all the most recent acme registration UUIDs that have been used in runs
+```
+$acme.files.:manifest():uuid()
+INTERSECT
+$*.results.:flatten():manifest():named_file_uuid()
+```
+
 #### 5.6b
 Note: when a function is used to retrieve the content of a file only one
 file may match the reference. For e.g., it is not possible to pull the

--- a/tests/references/test_files_reference_finder_3.py
+++ b/tests/references/test_files_reference_finder_3.py
@@ -618,9 +618,30 @@ STAR_BY_NAME = {
     "alpha": (STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST),
 }
 
+# a field accessor riding alongside a pointer during '*' traversal --
+# narrowed 2026-08-29 -- resolves via _extract_data()'s Star3-aware
+# branch, which reads the global arrivals ledger (result.uuid alone does
+# not say which named-file a candidate came from) -- these tests need a
+# ledger entry for every uuid any of them might resolve, unlike every
+# OTHER star-traversal test in this file, which never reads the ledger
+# at all.
+STAR_LEDGER = [
+    {"uuid": "u-zero-1"},
+    {"uuid": "u-one-1"},
+    {"uuid": "u-one-2"},
+    {"uuid": "u-two-1"},
+    {"uuid": "u-two-2"},
+]
+
 
 def _star_finder(reference: str) -> FilesReferenceFinder3:
-    return _finder(reference, STAR_ALPHA_HOME, STAR_ALPHA_MANIFEST, by_name=STAR_BY_NAME)
+    return _finder(
+        reference,
+        STAR_ALPHA_HOME,
+        STAR_ALPHA_MANIFEST,
+        by_name=STAR_BY_NAME,
+        ledger=STAR_LEDGER,
+    )
 
 
 class TestStarTraversalFlatten:
@@ -653,9 +674,13 @@ class TestStarTraversalFlatten:
         with pytest.raises(ReferenceException3):
             _star_finder("$*.files.*.:last():manifest()").query()
 
-    def test_combining_with_a_field_accessor_is_not_yet_supported(self):
-        with pytest.raises(ReferenceException3):
-            _star_finder("$*.files.*.:last():uuid()").query()
+    def test_combining_with_a_field_accessor_now_works(self):
+        # narrowed 2026-08-29 -- POOL mode always reduces to exactly one
+        # overall candidate, so a field accessor riding alongside the
+        # pointer is unambiguous the same way it already was for every
+        # other pointer+field-accessor position in this file.
+        results = _star_finder("$*.files.*.:last():uuid()").resolve()
+        assert results.results[0].data == "u-two-2"
 
     def test_functions_directly_on_name_one_not_yet_supported(self):
         with pytest.raises(ReferenceException3):
@@ -756,6 +781,16 @@ class TestStarTraversalGroup:
         with pytest.raises(ReferenceException3):
             _star_finder("$*.files.:all().:last():manifest()").query()
 
+    def test_all_combined_with_a_field_accessor_now_works(self):
+        # narrowed 2026-08-29 -- one value per (named-file, path) group,
+        # same as the literal-root ':all()' GROUP-mode fix the same day.
+        results = _star_finder("$*.files.:all().:last():uuid()").resolve()
+        assert {r.data for r in results.results} == {
+            "u-zero-1",
+            "u-one-2",
+            "u-two-2",
+        }
+
 
 #
 # adds one named-file ("gamma") with a TWO-level entry, chronologically
@@ -773,10 +808,13 @@ FLATTEN_GAMMA_MANIFEST = [
     },
 ]
 FLATTEN_BY_NAME = dict(STAR_BY_NAME, gamma=(FLATTEN_GAMMA_HOME, FLATTEN_GAMMA_MANIFEST))
+FLATTEN_LEDGER = STAR_LEDGER + [{"uuid": "u-gamma-deep-1"}]
 
 
 def _flatten_star_finder(reference: str) -> FilesReferenceFinder3:
-    csvpaths = _FakeCsvPaths(_FakeFileManager(None, None, by_name=FLATTEN_BY_NAME))
+    csvpaths = _FakeCsvPaths(
+        _FakeFileManager(None, None, by_name=FLATTEN_BY_NAME, ledger=FLATTEN_LEDGER)
+    )
     ref = ReferenceParser3(string=reference, csvpaths=csvpaths)
     return FilesReferenceFinder3(csvpaths=csvpaths, ref=ref)
 
@@ -808,11 +846,27 @@ class TestStarTraversalFlattenAnyDepth:
         }
 
     def test_combining_with_manifest_is_not_yet_supported(self):
-        # same structural reason '*' traversal has this restriction --
-        # root_major is "*" here, so _extract_data() cannot know which
-        # named-file's manifest to re-read.
+        # :manifest() (whole-resource) stays rejected here -- not a
+        # technical limit (_extract_data() can resolve it fine via the
+        # global ledger, same as Rule 1b's own :manifest()-with-pointer
+        # shape), but Rule 1: GROUP mode (see TestStarTraversalGroup/
+        # TestStarTraversalGroupsAnyDepth) can legitimately produce more
+        # than one reduced candidate, and this method's own return sets
+        # no ambiguous_content_read flag to catch that. ':flatten()' here
+        # is POOL mode though (always exactly one overall candidate) --
+        # kept consistent with :manifest()'s own blanket rejection in
+        # this method anyway, rather than carving out a POOL-only
+        # exception not asked for by any worked example.
         with pytest.raises(ReferenceException3):
             _flatten_star_finder("$*.files.:flatten().:last():manifest()").query()
+
+    def test_combining_with_a_field_accessor_now_works(self):
+        # narrowed 2026-08-29 -- POOL mode always reduces to exactly one
+        # overall candidate, so a field accessor riding alongside the
+        # pointer is unambiguous, the any-depth peer of '*' traversal's
+        # own POOL-mode fix (TestStarTraversalFlatten above).
+        results = _flatten_star_finder("$*.files.:flatten().:last():uuid()").resolve()
+        assert results.results[0].data == "u-gamma-deep-1"
 
 
 class TestStarTraversalGroupsAnyDepth:
@@ -836,6 +890,20 @@ class TestStarTraversalGroupsAnyDepth:
     def test_combining_with_manifest_is_not_yet_supported(self):
         with pytest.raises(ReferenceException3):
             _flatten_star_finder("$*.files.:groups().:last():manifest()").query()
+
+    def test_combining_with_a_field_accessor_now_works(self):
+        # narrowed 2026-08-29 -- one value per (named-file, path) group,
+        # any depth, including gamma's two-level entry ':all()' cannot
+        # reach.
+        results = _flatten_star_finder(
+            "$*.files.:groups().:last():uuid()"
+        ).resolve()
+        assert {r.data for r in results.results} == {
+            "u-zero-1",
+            "u-one-2",
+            "u-two-2",
+            "u-gamma-deep-1",
+        }
 
 
 #


### PR DESCRIPTION
## Summary

`$*.files.*.:last():uuid()` (POOL), `$*.files.:all().:last():uuid()`
(GROUP, one level), and `$*.files.:groups().:last():uuid()`/
`$*.files.:flatten().:last():uuid()` (any depth) all now work, instead
of raising -- the `'*'`-traversal peer of the literal-root GROUP-mode fix
from #274, one level broader (every traversal shape, not just the
literal-root one).

## Background

`_query_star_traversal()`'s shared name_three-processing tail had a
single blanket check rejecting `:manifest()` and any field accessor
together, for every traversal shape -- broader than the literal-root
check #274 narrowed. Traced the reduction logic just below it before
touching anything: it already independently reduces each `file_home`'s
own candidates (GROUP) or pools to one overall candidate (POOL)
regardless of which accessor rides alongside the pointer -- nothing
there needed to change.

The one new question this raised beyond the literal-root case:
`_extract_data()`'s Star3-aware branch (added in #272, reading the
global arrivals ledger since `result.uuid` alone does not say which
named-file a `'*'`-traversal candidate came from) needed to generalize
from the name_one-sourced `field_call` it was built for to a
name_three-sourced one too. Confirmed it already does -- that branch
lives inside the shared `if field_call is not None:` block -- so no code
change was needed there, only test fixtures needed a ledger they never
previously required (the shapes reaching that branch were always
rejected before).

`:manifest()` (whole-resource) stays rejected everywhere in this method,
deliberately -- GROUP mode can produce more than one reduced candidate,
and this method sets no `ambiguous_content_read` flag to catch resolving
several whole entries at once (Rule 1).

Also corrected a stale docstring/comment claiming the restriction
existed because `_extract_data()` "cannot know" which manifest to read --
no longer true (the Star3-aware ledger branch already solves that), and
Rule 1 was the real, still-current reason even before that.

## What changed

Narrowed the shared `unsupported` check from `has_manifest OR field_
accessor` to `has_manifest` only, mirroring #274's exact fix.

## Test plan

- [x] The one existing test asserting the old field-accessor rejection
      (POOL mode) converted to a positive assertion.
- [x] Three new tests added for shapes that were never testable before:
      GROUP one-level, GROUP any-depth, POOL any-depth.
- [x] `STAR_LEDGER`/`FLATTEN_LEDGER` fixtures added -- every other
      star-traversal test in this file still does not need one.
- [x] `:manifest()`-combined tests (still-correct rejection) left
      unchanged in every mode.
- [x] `tests/references/` full tree: 1563 passed.
- [x] Full suite run twice for stability: 3156 passed, 11 failed both
      times (identical) -- the known, unrelated SFTP/S3 failures
      requiring unset env vars (issue #216).

https://claude.ai/code/session_013gPjejPWvbWtjz2dw9h14M
